### PR TITLE
Deprecate RouteResultObserverInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ This package provides the following classes and interfaces:
   `ServerRequest` messages.
 - `Route`, a value object describing routed middleware.
 - `RouteResult`, a value object describing the results of routing.
-- `RouteResultObserverInterface`, which allows you to create observers for
-  `Zend\Expressive\Application` that will be updated when a `RouteResult` has
-  been obtained.
 
 ## Installation
 

--- a/src/RouteResultObserverInterface.php
+++ b/src/RouteResultObserverInterface.php
@@ -9,6 +9,10 @@
 
 namespace Zend\Expressive\Router;
 
+/**
+ * @deprecated Since 1.0.1. Use Zend\Expressive\RouteResultObserverInterface
+ *     from the zendframework/zend-expressive package instead.
+ */
 interface RouteResultObserverInterface
 {
     /**


### PR DESCRIPTION
This functionality was moved to zend-expressive in zendframework/zend-expressive#206.