### PR TITLE
Re-instate route result observer, and add subject

### DIFF
--- a/src/RouteResultObserverInterface.php
+++ b/src/RouteResultObserverInterface.php
@@ -10,8 +10,7 @@
 namespace Zend\Expressive\Router;
 
 /**
- * @deprecated Since 1.0.1. Use Zend\Expressive\RouteResultObserverInterface
- *     from the zendframework/zend-expressive package instead.
+ * An object that is interested in the route results.
  */
 interface RouteResultObserverInterface
 {

--- a/src/RouteResultSubjectInterface.php
+++ b/src/RouteResultSubjectInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router;
+
+/**
+ * Aggregate and notify route result observers.
+ *
+ * A route result subject typically composes a router, and will then notify
+ * observers of a route result returned by routing; the Application instance
+ * is typically the subject.
+ *
+ * @since 1.1.0
+ */
+interface RouteResultSubjectInterface
+{
+    /**
+     * Attach a route result observer.
+     *
+     * @param RouteResultObserverInterface $observer
+     */
+    public function attachRouteResultObserver(RouteResultObserverInterface $observer);
+
+    /**
+     * Detach a route result observer.
+     *
+     * If the observer was not previously attached, this is a no-op.
+     *
+     * @param RouteResultObserverInterface $observer
+     */
+    public function detachRouteResultObserver(RouteResultObserverInterface $observer);
+
+    /**
+     * Notify route result observers of a given route result.
+     */
+    public function notifyRouteResultObservers(RouteResult $result);
+}


### PR DESCRIPTION
This patch re-instates (de-deprecates) the `RouteResultObserverInterface`, but does so by adding its complement, the `RouteResultSubjectInterface`, which notifies observers of calculated route results. This latter interface is to be used with `Zend\Expressive\Application` (which already implements these methods on its master branch), but also allows observers the ability to depend only on this package for purposes of testing.