### PR TITLE
Deprecate the route result observer system

### DIFF
--- a/src/RouteResultObserverInterface.php
+++ b/src/RouteResultObserverInterface.php
@@ -11,6 +11,8 @@ namespace Zend\Expressive\Router;
 
 /**
  * An object that is interested in the route results.
+ *
+ * @deprecated since 1.2.0; will be removed in 2.0.0.
  */
 interface RouteResultObserverInterface
 {

--- a/src/RouteResultSubjectInterface.php
+++ b/src/RouteResultSubjectInterface.php
@@ -17,6 +17,8 @@ namespace Zend\Expressive\Router;
  * is typically the subject.
  *
  * @since 1.1.0
+ * @deprecated since 1.2.0; will be removed in 2.0.0. Zend\Expressive\Application
+ *     stopped implementing this as of 1.0.0RC6.
  */
 interface RouteResultSubjectInterface
 {


### PR DESCRIPTION
Per the changes in zendframework/zend-expressive#270, the route result observer system is no longer necessary, and is now deprecated.