### PR TITLE
Allow to set options as part of RouteResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.2.1 - TBD
+## 1.3.0 - TBD
 
 ### Added
 
-- Nothing.
+- Adds a new `getOptions` method as part of the `RouteResult` object. The options are optional and are
+retrieved from your route configuration.
 
 ### Deprecated
 

--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -52,6 +52,11 @@ class RouteResult
     private $matchedMiddleware;
 
     /**
+     * @var array
+     */
+    private $options;
+
+    /**
      * @var bool Success state of routing.
      */
     private $success;
@@ -63,15 +68,17 @@ class RouteResult
      * @param callable|string $middleware Middleware associated with the
      *     matched route.
      * @param array $params Parameters associated with the matched route.
+     * @param array $options Optional options bag associated with the matched route.
      * @return static
      */
-    public static function fromRouteMatch($name, $middleware, array $params)
+    public static function fromRouteMatch($name, $middleware, array $params, array $options = [])
     {
         $result                    = new self();
         $result->success           = true;
         $result->matchedRouteName  = $name;
         $result->matchedMiddleware = $middleware;
         $result->matchedParams     = $params;
+        $result->options           = $options;
         return $result;
     }
 
@@ -149,6 +156,21 @@ class RouteResult
     public function getMatchedParams()
     {
         return $this->matchedParams;
+    }
+
+    /**
+     * Returns the optional options.
+     *
+     * Note that this is different from the matched params. Those are optional options that are transmitted to
+     * the underlying router, but can also be used to embed metadata for the route. For instance, you may want
+     * some routes to be used in an unauthenticated way, so you could use the options to add this information
+     * as part of the route.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     /**


### PR DESCRIPTION
Hi,

I have a use case where I need some routes to be "unauthenticated". Unfortunately, they have the same base path so I cannot easily segregate them using different middlewares.

I first thought of simply creating my own config mechanism with a "unauthenticated_routes" and do the check, but I feel that the "options" parameter bag associated with route could also be used for any additional metadata.

Also, now that we have separated dispatched and routing middleware, it makes this trivial to use. For instance, here is a route definition:

```php
return [
    'routes' => [
          [
              'path' => '/api/projects',
              'options' => [
                  'requires_authentication' => false
              ]
          ]
    ]
]
```

The requires_authentication is a custom option that will now be available as part of the RouteResult. It therefore makes trivial for a `AuthenticationMiddleware` to check that, and if this is set to true, does not require authentication.

I'll update other packages as a consequence of this change.

PS: I can see that the "RouteResult" is not tested as part of this package. I didn't add test as a consequence but it may be a good idea to unit-test this class, especially as it contains quite a bit of logic.