### PR TITLE
Make path definition accessible in RouteResult

### DIFF
--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -44,6 +44,11 @@ class RouteResult
     /**
      * @var string
      */
+    private $matchedPath;
+
+    /**
+     * @var string
+     */
     private $matchedRouteName;
 
     /**
@@ -63,15 +68,17 @@ class RouteResult
      * @param callable|string $middleware Middleware associated with the
      *     matched route.
      * @param array $params Parameters associated with the matched route.
+     * @param string $path The path expression from the route config for the matched route.
      * @return static
      */
-    public static function fromRouteMatch($name, $middleware, array $params)
+    public static function fromRouteMatch($name, $middleware, array $params, $path)
     {
         $result                    = new self();
         $result->success           = true;
         $result->matchedRouteName  = $name;
         $result->matchedMiddleware = $middleware;
         $result->matchedParams     = $params;
+        $result->matchedPath       = $path;
         return $result;
     }
 
@@ -149,6 +156,16 @@ class RouteResult
     public function getMatchedParams()
     {
         return $this->matchedParams;
+    }
+
+    /**
+     * Returns the matched path.
+     *
+     * @return string
+     */
+    public function getMatchedPath()
+    {
+        return $this->matchedPath;
     }
 
     /**

--- a/test/RouteResultTest.php
+++ b/test/RouteResultTest.php
@@ -31,7 +31,8 @@ class RouteResultTest extends TestCase
         $result = RouteResult::fromRouteMatch(
             '/foo',
             $this->middleware,
-            []
+            [],
+            '/foo'
         );
         $this->assertSame($this->middleware, $result->getMatchedMiddleware());
     }
@@ -47,7 +48,8 @@ class RouteResultTest extends TestCase
         $result = RouteResult::fromRouteMatch(
             '/foo',
             $this->middleware,
-            []
+            [],
+            '/foo'
         );
         $this->assertEquals('/foo', $result->getMatchedRouteName());
     }
@@ -75,7 +77,8 @@ class RouteResultTest extends TestCase
         $result = RouteResult::fromRouteMatch(
             '/foo',
             $this->middleware,
-            []
+            [],
+            '/foo'
         );
         $this->assertSame([], $result->getAllowedMethods());
     }
@@ -86,7 +89,8 @@ class RouteResultTest extends TestCase
         $result = RouteResult::fromRouteMatch(
             '/foo',
             $this->middleware,
-            $params
+            $params,
+            '/foo'
         );
         $this->assertSame($params, $result->getMatchedParams());
     }
@@ -103,8 +107,15 @@ class RouteResultTest extends TestCase
         $result = RouteResult::fromRouteMatch(
             '/foo',
             $this->middleware,
-            $params
+            $params,
+            '/foo'
         );
         $this->assertFalse($result->isMethodFailure());
+    }
+
+    public function testMatchedPathIsRetrievable()
+    {
+        $result = RouteResult::fromRouteMatch('/foo', $this->middleware, [], '/foo[/bar]');
+        $this->assertSame('/foo[/bar]', $result->getMatchedPath());
     }
 }


### PR DESCRIPTION
This PR works towards addressing #12.

Using the skeleton application with the FastRoute router, I added the following route to the config:

``` php
        [
            'name' => 'api.user',
            'path' => '/user[/{id}]',
            'middleware' => App\Action\UserAction::class,
            'allowed_methods' => ['GET'],
        ],
```

The `UserAction` simply `var_dump`'ed the contents of `$request->getAttribute(RouteResult::class);`, which contained the `/user[/{id}]` matched path.

**Note:** The above also required modifying the Expressive FastRoute adapter to provide the path to `fromRouteMatch(...)`, which I just did a quick hack for locally to verify that it works. That repository (in addition to Expressive's AuraRouter and ZendRouter adapters) will need to be modified accordingly (which will require major version releases due to the BC break of updating the `generateUri` signature as part of c77431f3cc256f0da5de84a9f48072a9edb3263f).

Review + feedback appreciated! @xtreamwayz / @weierophinney 
