### PR TITLE
Implement `fromRoute()` and `getMatchedRoute()`

### DIFF
--- a/test/RouteResultTest.php
+++ b/test/RouteResultTest.php
@@ -107,4 +107,33 @@ class RouteResultTest extends TestCase
         );
         $this->assertFalse($result->isMethodFailure());
     }
+
+    public function testFromRouteShouldComposeRouteInResult()
+    {
+        $route = $this->prophesize(Route::class);
+
+        $result = RouteResult::fromRoute($route->reveal(), ['foo' => 'bar']);
+        $this->assertInstanceOf(RouteResult::class, $result);
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame($route->reveal(), $result->getMatchedRoute());
+
+        return ['route' => $route, 'result' => $result];
+    }
+
+    /**
+     * @depends testFromRouteShouldComposeRouteInResult
+     */
+    public function testAllAccessorsShouldReturnExpectedDataWhenResultCreatedViaFromRoute(array $data)
+    {
+        $result = $data['result'];
+        $route = $data['route'];
+
+        $route->getName()->willReturn('route');
+        $route->getMiddleware()->willReturn(__METHOD__);
+        $route->getAllowedMethods()->willReturn(['HEAD', 'OPTIONS', 'GET']);
+
+        $this->assertEquals('route', $result->getMatchedRouteName());
+        $this->assertEquals(__METHOD__, $result->getMatchedMiddleware());
+        $this->assertEquals(['HEAD', 'OPTIONS', 'GET'], $result->getAllowedMethods());
+    }
 }


### PR DESCRIPTION
`RouteResult::fromRoute()` expects a `Route` instance, and, optionally, the parameters matched during routing, and returns an instance representing a successful route match. The various getters, other than `getMatchedParams()`, then proxy to the underlying `Route` instance.  `getMatchedRoute()` returns the matched `Route` instance, allowing consumers to pull additional information from it, including the path, options, etc.

This patch also deprecates `fromRouteMatch()`, as it becomes redundant when the `Route` instance is present.

Finally, this patch would supercede #21 and fix #12, as the user could then perform the following to get the path:

```php
$result = $request->getAttribute(RouteResult::class);
$path = $result->getRoute()->getPath();
```

(The user would also now be able to retrieve allowed methods for the given route, using the `getAllowedMethods()` method on either the `RouteResult` or composed `Route`, making this solution more flexible.)

This approach is completely backwards compatible, but, because it provides new functionality, would require a new minor version (1.3.0 is the target).