### PR TITLE
Clarify that HEAD and OPTIONS should ALWAYS be allowed

### DIFF
--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -56,7 +56,9 @@ class RouteTest extends TestCase
     {
         $methods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
         $route = new Route('/foo', $this->noopMiddleware, $methods);
-        $this->assertSame($methods, $route->getAllowedMethods($methods));
+        foreach ($methods as $method) {
+            $this->assertContains($method, $route->getAllowedMethods());
+        }
     }
 
     public function testRouteCanMatchMethod()
@@ -181,6 +183,8 @@ class RouteTest extends TestCase
         $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]);
         $this->assertTrue($route->implicitHead());
         $this->assertTrue($route->implicitOptions());
+        $this->assertContains(RequestMethod::METHOD_HEAD, $route->getAllowedMethods());
+        $this->assertContains(RequestMethod::METHOD_OPTIONS, $route->getAllowedMethods());
     }
 
     public function headAndOptions()
@@ -198,6 +202,8 @@ class RouteTest extends TestCase
     {
         $route = new Route('/test', $this->noopMiddleware, [$httpMethod]);
         $this->assertFalse($route->{$implicitMethod}());
+        $this->assertContains(RequestMethod::METHOD_HEAD, $route->getAllowedMethods());
+        $this->assertContains(RequestMethod::METHOD_OPTIONS, $route->getAllowedMethods());
     }
 
     public function testPassingWildcardMethodDoesNotMarkAsImplicit()


### PR DESCRIPTION
The original point of #24 was to ensure that HEAD and OPTIONS are always allowable HTTP request methods for a given route. This patch adds those assumptions to the tests added for #24, and updates `Route` accordingly.