### PR TITLE
Revert "Clarify that HEAD and OPTIONS should ALWAYS be allowed"

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -33,13 +33,13 @@ class Route
      * @var bool If HEAD was not provided to the Route instance, indicate
      *     support for the method is implicit.
      */
-    private $implicitHead = false;
+    private $implicitHead = true;
 
     /**
      * @var bool If OPTIONS was not provided to the Route instance, indicate
      *     support for the method is implicit.
      */
-    private $implicitOptions = false;
+    private $implicitOptions = true;
 
     /**
      * @var int|string[] HTTP methods allowed with this route.
@@ -99,9 +99,14 @@ class Route
         if (empty($name)) {
             $name = ($this->methods === self::HTTP_METHOD_ANY)
                 ? $path
-                : $path . '^' . implode(self::HTTP_METHOD_SEPARATOR, $this->retrieveExplicitMethods($this->methods));
+                : $path . '^' . implode(self::HTTP_METHOD_SEPARATOR, $this->methods);
         }
         $this->name = $name;
+
+        $this->implicitHead = is_array($this->methods)
+            && ! in_array(RequestMethod::METHOD_HEAD, $this->methods, true);
+        $this->implicitOptions = is_array($this->methods)
+            && ! in_array(RequestMethod::METHOD_OPTIONS, $this->methods, true);
     }
 
     /**
@@ -155,7 +160,9 @@ class Route
     public function allowsMethod($method)
     {
         $method = strtoupper($method);
-        if ($this->methods === self::HTTP_METHOD_ANY
+        if (RequestMethod::METHOD_HEAD === $method
+            || RequestMethod::METHOD_OPTIONS === $method
+            || $this->methods === self::HTTP_METHOD_ANY
             || in_array($method, $this->methods, true)
         ) {
             return true;
@@ -229,40 +236,6 @@ class Route
             throw new Exception\InvalidArgumentException('One or more HTTP methods were invalid');
         }
 
-        if (! in_array(RequestMethod::METHOD_HEAD, $methods, true)) {
-            $this->implicitHead = true;
-            $methods[] = RequestMethod::METHOD_HEAD;
-        }
-
-        if (! in_array(RequestMethod::METHOD_OPTIONS, $methods, true)) {
-            $this->implicitOptions = true;
-            $methods[] = RequestMethod::METHOD_OPTIONS;
-        }
-
         return array_map('strtoupper', $methods);
-    }
-
-    /**
-     * Return a list of methods explicitly set when creating the route.
-     *
-     * Filters out HEAD and/or OPTIONS if they were set implicitly.
-     */
-    private function retrieveExplicitMethods(array $methods)
-    {
-        return array_filter($methods, function ($method) {
-            if (! in_array($method, [RequestMethod::METHOD_HEAD, RequestMethod::METHOD_OPTIONS], true)) {
-                return true;
-            }
-
-            if ($method === RequestMethod::METHOD_HEAD && ! $this->implicitHead) {
-                return true;
-            }
-
-            if ($method === RequestMethod::METHOD_OPTIONS && ! $this->implicitOptions) {
-                return true;
-            }
-
-            return false;
-        });
     }
 }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -56,9 +56,7 @@ class RouteTest extends TestCase
     {
         $methods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
         $route = new Route('/foo', $this->noopMiddleware, $methods);
-        foreach ($methods as $method) {
-            $this->assertContains($method, $route->getAllowedMethods());
-        }
+        $this->assertSame($methods, $route->getAllowedMethods($methods));
     }
 
     public function testRouteCanMatchMethod()
@@ -183,8 +181,6 @@ class RouteTest extends TestCase
         $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]);
         $this->assertTrue($route->implicitHead());
         $this->assertTrue($route->implicitOptions());
-        $this->assertContains(RequestMethod::METHOD_HEAD, $route->getAllowedMethods());
-        $this->assertContains(RequestMethod::METHOD_OPTIONS, $route->getAllowedMethods());
     }
 
     public function headAndOptions()
@@ -202,8 +198,6 @@ class RouteTest extends TestCase
     {
         $route = new Route('/test', $this->noopMiddleware, [$httpMethod]);
         $this->assertFalse($route->{$implicitMethod}());
-        $this->assertContains(RequestMethod::METHOD_HEAD, $route->getAllowedMethods());
-        $this->assertContains(RequestMethod::METHOD_OPTIONS, $route->getAllowedMethods());
     }
 
     public function testPassingWildcardMethodDoesNotMarkAsImplicit()


### PR DESCRIPTION
This reverts commit a81bf26435015cc28f2bc411460488e31ec2fd8f.

Per #28, auto-adding the HEAD and OPTIONS methods to each route causes `Zend\Expressive\Application` to raise an exception; additionally, when working on zendframework/zend-expressive-fastroute#24, I noticed that tests broke due to duplicate paths having the same HTTP method defined; adding HEAD and/or OPTIONS was causing adding routes with GET to result in exceptions.

There are other ways for the routers to accommodate this, which can be done with the `implicitHead()` and `implicitOptions()` methods of the routes themselves, or by opportunistically checking for any method to match against a given path.