### PR TITLE
Added support for http-interop/http-middleware 0.5.0 (No BC Break)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         "psr",
         "psr-7"
     ],
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.1-dev",
@@ -18,9 +21,9 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "psr/http-message": "^1.0.1",
         "fig/http-message-util": "^1.1.2",
-        "http-interop/http-middleware": "^0.4.1"
+        "psr/http-message": "^1.0.1",
+        "webimpress/http-middleware-compatibility": "^0.1.1"
     },
     "require-dev": {
       "malukenho/docheader": "^0.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a89ad5482362322644a7efc94a615772",
+    "content-hash": "e476afac49dbb57f355d0c27565311ea",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -157,6 +157,46 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Route.php
+++ b/src/Route.php
@@ -8,7 +8,7 @@
 namespace Zend\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Value object representing a single route.

--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -7,7 +7,7 @@
 
 namespace Zend\Expressive\Router;
 
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Value object representing the results of routing.

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -8,8 +8,8 @@
 namespace ZendTest\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use PHPUnit\Framework\TestCase;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Router\Exception\InvalidArgumentException;
 use Zend\Expressive\Router\Route;
 


### PR DESCRIPTION
We keep also support for `http-interop/http-middleware 0.4.1`. We use `webimpress/http-middleware-compatibility` to keep compatibility with all versions of http-middleware. So customer of the library can use any version of http-middleware and migrate at any time to the latest version.

`composer.lock` is currently with version 0.4.1 of http-interop middleware, so tests run with:
- lowest - 0.1.1
- locked - 0.4.1
- latest - 0.5.0