### PR TITLE
Removed condition to prove that it's not covered in tests

### DIFF
--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -183,7 +183,7 @@ class RouteResult
      */
     public function isMethodFailure() : bool
     {
-        if ($this->isSuccess() || ['*'] === $this->allowedMethods) {
+        if ($this->isSuccess()) {
             return false;
         }
 


### PR DESCRIPTION
If the condition is right we should have test for it. As you can see in this PR all tests are fine, and part of the if statement is removed.

See: https://github.com/zendframework/zend-expressive-router/commit/a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d

Ping @weierophinney 