### PR TITLE
Remove default value for initial argument to `fromRouteFailure()`

### DIFF
--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -83,9 +83,10 @@ class RouteResult
     /**
      * Create an instance representing a route failure.
      *
-     * @param null|array $methods HTTP methods allowed for the current URI, if any
+     * @param null|array $methods HTTP methods allowed for the current URI, if any.
+     *     null is equivalent to allowing any HTTP method; empty array means none.
      */
-    public static function fromRouteFailure(?array $methods = []) : self
+    public static function fromRouteFailure(?array $methods) : self
     {
         $result = new self();
         $result->success = false;

--- a/test/RouteResultTest.php
+++ b/test/RouteResultTest.php
@@ -29,13 +29,13 @@ class RouteResultTest extends TestCase
 
     public function testRouteMiddlewareIsNotRetrievable()
     {
-        $result = RouteResult::fromRouteFailure();
+        $result = RouteResult::fromRouteFailure([]);
         $this->assertFalse($result->getMatchedMiddleware());
     }
 
     public function testRouteNameIsNotRetrievable()
     {
-        $result = RouteResult::fromRouteFailure();
+        $result = RouteResult::fromRouteFailure([]);
         $this->assertFalse($result->getMatchedRouteName());
     }
 
@@ -47,7 +47,7 @@ class RouteResultTest extends TestCase
 
     public function testRouteFailureRetrieveHttpMethods()
     {
-        $result = RouteResult::fromRouteFailure();
+        $result = RouteResult::fromRouteFailure([]);
         $this->assertSame([], $result->getAllowedMethods());
     }
 
@@ -111,5 +111,22 @@ class RouteResultTest extends TestCase
     {
         $result = RouteResult::fromRouteFailure([]);
         $this->assertTrue($result->isMethodFailure());
+    }
+
+    public function testFailureResultDoesNotIndicateAMethodFailureIfAllMethodsAreAllowed()
+    {
+        $result = RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
+        $this->assertTrue($result->isFailure());
+        $this->assertFalse($result->isMethodFailure());
+        return $result;
+    }
+
+    /**
+     * @depends testFailureResultDoesNotIndicateAMethodFailureIfAllMethodsAreAllowed
+     */
+    public function testAllowedMethodsIncludesASingleWildcardEntryWhenAllMethodsAllowedForFailureResult(
+        RouteResult $result
+    ) {
+        $this->assertSame(['*'], $result->getAllowedMethods());
     }
 }


### PR DESCRIPTION
Currently, phpspec/prophecy does not properly mock method arguments that are nullable if the default value is not also `null`. This raised an interesting design issue for `RouteResult::fromResultFailure()`, as the change to use a nullable argument where the default value is an empty array instead then caused test errors.

In reviewing the functionality, a default argument makes no sense. We should pass in exactly what we intend: the allowed methods for the failed route match, if any. Routers should then pass in:

- `Route::HTTP_METHOD_ANY` if all methods are allowed; this will be true for 404 errors, where no route was matched, too!
- An empty array, if no methods are allowed (which likely indicates a malformed route).
- A populated array.

This patch updates to that behavior, and adds tests to verify behavior of the result once created.

Supercedes #42.