### PR TITLE
Imports routing and dispatch middleware from proposed Expressive v3 branch

### DIFF
--- a/src/DispatchMiddleware.php
+++ b/src/DispatchMiddleware.php
@@ -1,62 +1,38 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Router;
 
-use Interop\Http\Middleware\ServerMiddlewareInterface as LegacyLegacyMiddlewareInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as LegacyMiddlewareInterface;
-use Interop\Http\Server\MiddlewareInterface as InteropMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Default dispatch middleware.
  *
  * Checks for a composed route result in the request. If none is provided,
- * delegates to the next middleware.
+ * delegates request processing to the handler.
  *
- * Otherwise, it pulls the middleware from the route result. If the middleware
- * is not http-interop middleware, it raises an exception. This means that
- * this middleware is incompatible with routes that store non-http-interop
- * middleware instances! Make certain you only provide middleware instances
- * to your router when using this middleware.
+ * Otherwise, it pulls the middleware from the route result and processes it
+ * with the provided request and handler.
  */
 class DispatchMiddleware implements MiddlewareInterface
 {
-    /**
-     * @param ServerRequestInterface $request
-     * @param HandlerInterface $handler
-     * @return ResponseInterface
-     */
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $routeResult = $request->getAttribute(RouteResult::class, false);
         if (! $routeResult) {
-            return $handler->{HANDLER_METHOD}($request);
+            return $handler->handle($request);
         }
 
         $middleware = $routeResult->getMatchedMiddleware();
-
-        if (! $middleware instanceof LegacyLegacyMiddlewareInterface
-            && ! $middleware instanceof LegacyMiddlewareInterface
-            && ! $middleware instanceof InteropMiddlewareInterface
-        ) {
-            throw new Exception\RuntimeException(sprintf(
-                'Unknown middleware type stored in route; %s expects an http-interop'
-                . ' middleware instance; received %s',
-                __CLASS__,
-                is_object($middleware) ? get_class($middleware) : gettype($middleware)
-            ));
-        }
-
         return $middleware->process($request, $handler);
     }
 }

--- a/src/Exception/DuplicateRouteException.php
+++ b/src/Exception/DuplicateRouteException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Exception;
+
+use DomainException;
+
+class DuplicateRouteException extends DomainException implements
+    ExceptionInterface
+{
+}

--- a/src/PathBasedRoutingMiddleware.php
+++ b/src/PathBasedRoutingMiddleware.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Psr\Http\Server\MiddlewareInterface;
+
+/**
+ * Routing middleware for path-based routes.
+ *
+ * This middleware extends the RouteMiddleware in order to provide additional
+ * methods for creating path+HTTP method-based routes:
+ *
+ * - get
+ * - post
+ * - put
+ * - patch
+ * - delete
+ * - any
+ *
+ * A general `route()` method allows specifying multiple request methods and/or
+ * arbitrary request methods when creating a path-based route.
+ *
+ * Internally, the middleware performs some checks for duplicate routes when
+ * attaching via one of the exposed methods, and will raise an exception when a
+ * collision occurs.
+ */
+class PathBasedRoutingMiddleware extends RouteMiddleware
+{
+    /**
+     * List of all routes registered directly with the application.
+     *
+     * @var Route[]
+     */
+    private $routes = [];
+
+    /**
+     * Add a route for the route middleware to match.
+     *
+     * Accepts a combination of a path and middleware, and optionally the HTTP methods allowed.
+     *
+     * @param null|array $methods HTTP method to accept; null indicates any.
+     * @param null|string $name The name of the route.
+     * @throws Exception\DuplicateRouteException if specification represents an existing route.
+     */
+    public function route(
+        string $path,
+        MiddlewareInterface $middleware,
+        array $methods = null,
+        string $name = null
+    ) : Route {
+        $this->checkForDuplicateRoute($path, $methods);
+
+        $methods = null === $methods ? Route::HTTP_METHOD_ANY : $methods;
+        $route   = new Route($path, $middleware, $methods, $name);
+
+        $this->routes[] = $route;
+        $this->router->addRoute($route);
+
+        return $route;
+    }
+
+    /**
+     * @param null|string $name The name of the route.
+     */
+    public function get(string $path, MiddlewareInterface $middleware, string $name = null) : Route
+    {
+        return $this->route($path, $middleware, ['GET'], $name);
+    }
+
+    /**
+     * @param null|string $name The name of the route.
+     */
+    public function post(string $path, MiddlewareInterface $middleware, string $name = null) : Route
+    {
+        return $this->route($path, $middleware, ['POST'], $name);
+    }
+
+    /**
+     * @param null|string $name The name of the route.
+     */
+    public function put(string $path, MiddlewareInterface $middleware, string $name = null) : Route
+    {
+        return $this->route($path, $middleware, ['PUT'], $name);
+    }
+
+    /**
+     * @param null|string $name The name of the route.
+     */
+    public function patch(string $path, MiddlewareInterface $middleware, string $name = null) : Route
+    {
+        return $this->route($path, $middleware, ['PATCH'], $name);
+    }
+
+    /**
+     * @param null|string $name The name of the route.
+     */
+    public function delete(string $path, MiddlewareInterface $middleware, string $name = null) : Route
+    {
+        return $this->route($path, $middleware, ['DELETE'], $name);
+    }
+
+    /**
+     * @param null|string $name The name of the route.
+     */
+    public function any(string $path, MiddlewareInterface $middleware, string $name = null) : Route
+    {
+        return $this->route($path, $middleware, null, $name);
+    }
+
+    /**
+     * Retrieve all directly registered routes with the application.
+     *
+     * @return Route[]
+     */
+    public function getRoutes() : array
+    {
+        return $this->routes;
+    }
+
+    /**
+     * Determine if the route is duplicated in the current list.
+     *
+     * Checks if a route with the same name or path exists already in the list;
+     * if so, and it responds to any of the $methods indicated, raises
+     * a DuplicateRouteException indicating a duplicate route.
+     *
+     * @throws Exception\DuplicateRouteException on duplicate route detection.
+     */
+    private function checkForDuplicateRoute(string $path, array $methods = null) : void
+    {
+        if (null === $methods) {
+            $methods = Route::HTTP_METHOD_ANY;
+        }
+
+        $matches = array_filter($this->routes, function (Route $route) use ($path, $methods) {
+            if ($path !== $route->getPath()) {
+                return false;
+            }
+
+            if ($methods === Route::HTTP_METHOD_ANY) {
+                return true;
+            }
+
+            return array_reduce($methods, function ($carry, $method) use ($route) {
+                return ($carry || $route->allowsMethod($method));
+            }, false);
+        });
+
+        if (! empty($matches)) {
+            throw new Exception\DuplicateRouteException(
+                'Duplicate route detected; same name or path, and one or more HTTP methods intersect'
+            );
+        }
+    }
+}

--- a/src/PathBasedRoutingMiddleware.php
+++ b/src/PathBasedRoutingMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/RouteMiddleware.php
+++ b/src/RouteMiddleware.php
@@ -10,12 +10,8 @@ namespace Zend\Expressive\Router;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\Router\RouterInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Default routing middleware.
@@ -42,24 +38,15 @@ class RouteMiddleware implements MiddlewareInterface
     /**
      * @var RouterInterface
      */
-    private $router;
+    protected $router;
 
-    /**
-     * @param RouterInterface $router
-     * @param ResponseInterface $responsePrototype
-     */
     public function __construct(RouterInterface $router, ResponseInterface $responsePrototype)
     {
         $this->router = $router;
         $this->responsePrototype = $responsePrototype;
     }
 
-    /**
-     * @param ServerRequestInterface $request
-     * @param HandlerInterface $handler
-     * @return ResponseInterface
-     */
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $result = $this->router->match($request);
 
@@ -68,7 +55,7 @@ class RouteMiddleware implements MiddlewareInterface
                 return $this->responsePrototype->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
                     ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
             }
-            return $handler->{HANDLER_METHOD}($request);
+            return $handler->handle($request);
         }
 
         // Inject the actual route result, as well as individual matched parameters.
@@ -77,6 +64,6 @@ class RouteMiddleware implements MiddlewareInterface
             $request = $request->withAttribute($param, $value);
         }
 
-        return $handler->{HANDLER_METHOD}($request);
+        return $handler->handle($request);
     }
 }

--- a/src/RouteMiddleware.php
+++ b/src/RouteMiddleware.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Router;
 

--- a/test/DispatchMiddlewareTest.php
+++ b/test/DispatchMiddlewareTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 
@@ -11,50 +13,52 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\DispatchMiddleware;
-use Zend\Expressive\Router\Exception\RuntimeException;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
-
 class DispatchMiddlewareTest extends TestCase
 {
-    /** @var HandlerInterface|ObjectProphecy */
+    /** @var RequestHandlerInterface|ObjectProphecy */
     private $handler;
 
     /** @var DispatchMiddleware */
     private $middleware;
 
+    /** @var ServerRequestInterface|ObjectProphecy */
+    private $request;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $responsePrototype;
+
     public function setUp()
     {
+        $this->response   = $this->prophesize(ResponseInterface::class)->reveal();
         $this->request    = $this->prophesize(ServerRequestInterface::class);
-        $this->handler    = $this->prophesize(HandlerInterface::class);
+        $this->handler    = $this->prophesize(RequestHandlerInterface::class);
         $this->middleware = new DispatchMiddleware();
     }
 
-    public function testInvokesDelegateIfRequestDoesNotContainRouteResult()
+    public function testInvokesHandlerIfRequestDoesNotContainRouteResult()
     {
-        $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $this->request->getAttribute(RouteResult::class, false)->willReturn(false);
-        $this->handler->{HANDLER_METHOD}($this->request->reveal())->willReturn($expected);
+        $this->handler->handle($this->request->reveal())->willReturn($this->response);
 
         $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 
-        $this->assertSame($expected, $response);
+        $this->assertSame($this->response, $response);
     }
 
     public function testInvokesMatchedMiddlewareWhenRouteResult()
     {
-        $this->handler->{HANDLER_METHOD}()->shouldNotBeCalled();
+        $this->handler->handle()->shouldNotBeCalled();
 
-        $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $routedMiddleware = $this->prophesize(MiddlewareInterface::class);
         $routedMiddleware
             ->process($this->request->reveal(), $this->handler->reveal())
-            ->willReturn($expected);
+            ->willReturn($this->response);
 
         $routeResult = RouteResult::fromRoute(new Route('/', $routedMiddleware->reveal()));
 
@@ -62,35 +66,6 @@ class DispatchMiddlewareTest extends TestCase
 
         $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 
-        $this->assertSame($expected, $response);
-    }
-
-    public function invalidMiddleware()
-    {
-        return [
-            // @codingStandardsIgnoreStart
-            // There are more types we could test, but Route has a number of tests
-            // in place already, and these are the three it allows that the dispatch
-            // middleware cannot allow.
-            'string'   => ['middleware'],
-            'array'    => [['middleware']],
-            'callable' => [function () {}],
-            // @codingStandardsIgnoreEnd
-        ];
-    }
-
-    /**
-     * @dataProvider invalidMiddleware
-     * @param mixed $middleware
-     */
-    public function testInvalidRoutedMiddlewareInRouteResultResultsInException($middleware)
-    {
-        $this->handler->{HANDLER_METHOD}()->shouldNotBeCalled();
-        $routeResult = RouteResult::fromRoute(new Route('/', $middleware));
-        $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('expects an http-interop');
-        $this->middleware->process($this->request->reveal(), $this->handler->reveal());
+        $this->assertSame($this->response, $response);
     }
 }

--- a/test/PathBasedRoutingMiddlewareTest.php
+++ b/test/PathBasedRoutingMiddlewareTest.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TypeError;
+use Zend\Expressive\Router\Exception;
+use Zend\Expressive\Router\PathBasedRoutingMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
+
+class PathBasedRoutingMiddlewareTest extends TestCase
+{
+    /** @var RouterInterface|ObjectProphecy */
+    private $router;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    /** @var PathBasedRoutingMiddleware */
+    private $middleware;
+
+    /** @var ServerRequestInterface|ObjectProphecy */
+    private $request;
+
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
+
+    public function setUp()
+    {
+        $this->router     = $this->prophesize(RouterInterface::class);
+        $this->response   = $this->prophesize(ResponseInterface::class);
+        $this->middleware = new PathBasedRoutingMiddleware(
+            $this->router->reveal(),
+            $this->response->reveal()
+        );
+
+        $this->request  = $this->prophesize(ServerRequestInterface::class);
+        $this->handler = $this->prophesize(RequestHandlerInterface::class);
+        $this->noopMiddleware = $this->createNoopMiddleware();
+    }
+
+    public function createNoopMiddleware()
+    {
+        return new class ($this->response->reveal()) implements MiddlewareInterface {
+            private $response;
+
+            public function __construct(ResponseInterface $response)
+            {
+                $this->response = $response;
+            }
+
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+    }
+
+    public function commonHttpMethods()
+    {
+        return [
+            'GET'    => ['GET'],
+            'POST'   => ['POST'],
+            'PUT'    => ['PUT'],
+            'PATCH'  => ['PATCH'],
+            'DELETE' => ['DELETE'],
+        ];
+    }
+
+    public function testRouteMethodReturnsRouteInstance()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
+        $route = $this->middleware->route('/foo', $this->noopMiddleware);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('/foo', $route->getPath());
+        $this->assertSame($this->noopMiddleware, $route->getMiddleware());
+    }
+
+    public function testAnyRouteMethod()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
+        $route = $this->middleware->any('/foo', $this->noopMiddleware);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('/foo', $route->getPath());
+        $this->assertSame($this->noopMiddleware, $route->getMiddleware());
+        $this->assertSame(Route::HTTP_METHOD_ANY, $route->getAllowedMethods());
+    }
+
+    /**
+     * @dataProvider commonHttpMethods
+     *
+     * @param string $method
+     */
+    public function testCanCallRouteWithHttpMethods($method)
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
+        $route = $this->middleware->route('/foo', $this->noopMiddleware, [$method]);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('/foo', $route->getPath());
+        $this->assertSame($this->noopMiddleware, $route->getMiddleware());
+        $this->assertTrue($route->allowsMethod($method));
+        $this->assertSame([$method], $route->getAllowedMethods());
+    }
+
+    public function testCanCallRouteWithMultipleHttpMethods()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
+        $methods = array_keys($this->commonHttpMethods());
+        $route = $this->middleware->route('/foo', $this->noopMiddleware, $methods);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('/foo', $route->getPath());
+        $this->assertSame($this->noopMiddleware, $route->getMiddleware());
+        $this->assertSame($methods, $route->getAllowedMethods());
+    }
+
+    public function testCallingRouteWithExistingPathAndOmittingMethodsArgumentRaisesException()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
+        $this->middleware->route('/foo', $this->noopMiddleware);
+        $this->middleware->route('/bar', $this->noopMiddleware);
+        $this->expectException(Exception\DuplicateRouteException::class);
+        $this->middleware->route('/foo', $this->createNoopMiddleware());
+    }
+
+    public function invalidPathTypes()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'array'      => [['path' => 'route']],
+            'object'     => [(object) ['path' => 'route']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidPathTypes
+     *
+     * @param mixed $path
+     */
+    public function testCallingRouteWithAnInvalidPathTypeRaisesAnException($path)
+    {
+        $this->expectException(TypeError::class);
+        $this->middleware->route($path, $this->createNoopMiddleware());
+    }
+
+    /**
+     * @dataProvider commonHttpMethods
+     *
+     * @param mixed $method
+     */
+    public function testCommonHttpMethodsAreExposedAsClassMethodsAndReturnRoutes($method)
+    {
+        $route = $this->middleware->{$method}('/foo', $this->noopMiddleware);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('/foo', $route->getPath());
+        $this->assertSame($this->noopMiddleware, $route->getMiddleware());
+        $this->assertEquals([$method], $route->getAllowedMethods());
+    }
+
+    public function testCreatingHttpRouteMethodWithExistingPathButDifferentMethodCreatesNewRouteInstance()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
+        $route = $this->middleware->route('/foo', $this->noopMiddleware, []);
+
+        $middleware = $this->createNoopMiddleware();
+        $test = $this->middleware->get('/foo', $middleware);
+        $this->assertNotSame($route, $test);
+        $this->assertSame($route->getPath(), $test->getPath());
+        $this->assertSame(['GET'], $test->getAllowedMethods());
+        $this->assertSame($middleware, $test->getMiddleware());
+    }
+
+    public function testCreatingHttpRouteWithExistingPathAndMethodRaisesException()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
+        $this->middleware->get('/foo', $this->noopMiddleware);
+
+        $this->expectException(Exception\DuplicateRouteException::class);
+        $this->middleware->get('/foo', $this->createNoopMiddleware());
+    }
+}

--- a/test/PathBasedRoutingMiddlewareTest.php
+++ b/test/PathBasedRoutingMiddlewareTest.php
@@ -64,8 +64,10 @@ class PathBasedRoutingMiddlewareTest extends TestCase
                 $this->response = $response;
             }
 
-            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
-            {
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ) : ResponseInterface {
                 return $this->response;
             }
         };

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 


### PR DESCRIPTION
This patch pulls the `RouteMiddleware` and `DispatchMiddleware` as written in the [Expressive v3 refactor patch](https://github.com/zendframework/zend-expressive/pull/543) for the proposed v3 of zend-expressive-router.

In particular:

- `RouteMiddleware` and `DispatchMiddleware` are updated to PSR-15.
- `RouteMiddleware` marks the `$router` property as `protected`, to allow extension.
- The zend-expressive `RouteMiddleware` is imported as `PathBasedRoutingMiddleware`, and updated:
  - it now extends `Zend\Expressive\Router\RouteMiddleware`.
  - it only defines the various routing methods, as the constructor and `process()` method can be used verbatim.