### PR TITLE
Refactor routing and dispatch logic

### DIFF
--- a/src/DispatchMiddleware.php
+++ b/src/DispatchMiddleware.php
@@ -20,8 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Checks for a composed route result in the request. If none is provided,
  * delegates request processing to the handler.
  *
- * Otherwise, it pulls the middleware from the route result and processes it
- * with the provided request and handler.
+ * Otherwise, it delegates processing to the route result.
  */
 class DispatchMiddleware implements MiddlewareInterface
 {
@@ -32,7 +31,6 @@ class DispatchMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $middleware = $routeResult->getMatchedMiddleware();
-        return $middleware->process($request, $handler);
+        return $routeResult->process($request, $handler);
     }
 }

--- a/src/MethodNotAllowedMiddleware.php
+++ b/src/MethodNotAllowedMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Emit a 405 Method Not Allowed response
+ *
+ * If the request composes a route result, and the route result represents a
+ * failure due to request method, this middleware will emit a 405 response,
+ * along with an Allow header indicating allowed methods, as reported by the
+ * route result.
+ *
+ * If no route result is composed, and/or it's not the result of a method
+ * failure, it passes handling to the provided handler.
+ */
+class MethodNotAllowedMiddleware implements MiddlewareInterface
+{
+    /**
+     * Response prototype for 405 responses.
+     *
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ResponseInterface $responsePrototype)
+    {
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        $routeResult = $request->getAttribute(RouteResult::class, false);
+        if (! $routeResult || ! $routeResult->isMethodFailure()) {
+            return $handler->handle($request);
+        }
+
+        return $this->responsePrototype
+            ->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
+            ->withHeader('Allow', implode(',', $routeResult->getAllowedMethods()));
+    }
+}

--- a/src/MethodNotAllowedMiddleware.php
+++ b/src/MethodNotAllowedMiddleware.php
@@ -42,7 +42,7 @@ class MethodNotAllowedMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $routeResult = $request->getAttribute(RouteResult::class, false);
+        $routeResult = $request->getAttribute(RouteResult::class);
         if (! $routeResult || ! $routeResult->isMethodFailure()) {
             return $handler->handle($request);
         }

--- a/src/Route.php
+++ b/src/Route.php
@@ -10,7 +10,10 @@ declare(strict_types=1);
 namespace Zend\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Value object representing a single route.
@@ -27,7 +30,7 @@ use Psr\Http\Server\MiddlewareInterface;
  * be provided after instantiation via the "options" property and related
  * setOptions() method.
  */
-class Route
+class Route implements MiddlewareInterface
 {
     public const HTTP_METHOD_ANY = null;
     public const HTTP_METHOD_SEPARATOR = ':';
@@ -96,6 +99,14 @@ class Route
             && ! in_array(RequestMethod::METHOD_HEAD, $this->methods, true);
         $this->implicitOptions = is_array($this->methods)
             && ! in_array(RequestMethod::METHOD_OPTIONS, $this->methods, true);
+    }
+
+    /**
+     * Proxies to the middleware composed during instantiation.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        return $this->middleware->process($request, $handler);
     }
 
     public function getPath() : string

--- a/src/RouteMiddleware.php
+++ b/src/RouteMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Router;
 
-use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -18,52 +17,36 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Default routing middleware.
  *
- * Uses the composed router to match against the incoming request.
+ * Uses the composed router to match against the incoming request, and
+ * injects the request passed to the handler with the `RouteResult` instance
+ * returned (using the `RouteResult` class name as the attribute name).
  *
- * When routing failure occurs, if the failure is due to HTTP method, uses
- * the composed response prototype to generate a 405 response; otherwise,
- * it delegates to the next middleware.
- *
- * If routing succeeds, injects the route result into the request (under the
- * RouteResult class name), as well as any matched parameters, before
- * delegating to the next middleware.
+ * If routing succeeds, injects the request passed to the handler with any
+ * matched parameters as well.
  */
 class RouteMiddleware implements MiddlewareInterface
 {
-    /**
-     * Response prototype for 405 responses.
-     *
-     * @var ResponseInterface
-     */
-    private $responsePrototype;
-
     /**
      * @var RouterInterface
      */
     protected $router;
 
-    public function __construct(RouterInterface $router, ResponseInterface $responsePrototype)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
-        $this->responsePrototype = $responsePrototype;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $result = $this->router->match($request);
 
-        if ($result->isFailure()) {
-            if ($result->isMethodFailure()) {
-                return $this->responsePrototype->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
-                    ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
-            }
-            return $handler->handle($request);
-        }
-
         // Inject the actual route result, as well as individual matched parameters.
         $request = $request->withAttribute(RouteResult::class, $result);
-        foreach ($result->getMatchedParams() as $param => $value) {
-            $request = $request->withAttribute($param, $value);
+
+        if ($result->isSuccess()) {
+            foreach ($result->getMatchedParams() as $param => $value) {
+                $request = $request->withAttribute($param, $value);
+            }
         }
 
         return $handler->handle($request);

--- a/test/DispatchMiddlewareTest.php
+++ b/test/DispatchMiddlewareTest.php
@@ -30,7 +30,7 @@ class DispatchMiddlewareTest extends TestCase
     private $request;
 
     /** @var ResponseInterface|ObjectProphecy */
-    private $responsePrototype;
+    private $response;
 
     public function setUp()
     {

--- a/test/DispatchMiddlewareTest.php
+++ b/test/DispatchMiddlewareTest.php
@@ -16,7 +16,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\DispatchMiddleware;
-use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 
 class DispatchMiddlewareTest extends TestCase

--- a/test/DispatchMiddlewareTest.php
+++ b/test/DispatchMiddlewareTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Router;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\DispatchMiddleware;
 use Zend\Expressive\Router\Route;
@@ -51,18 +51,19 @@ class DispatchMiddlewareTest extends TestCase
         $this->assertSame($this->response, $response);
     }
 
-    public function testInvokesMatchedMiddlewareWhenRouteResult()
+    public function testInvokesRouteResultWhenPresent()
     {
-        $this->handler->handle()->shouldNotBeCalled();
+        $this->handler->handle(Argument::any())->shouldNotBeCalled();
 
-        $routedMiddleware = $this->prophesize(MiddlewareInterface::class);
-        $routedMiddleware
-            ->process($this->request->reveal(), $this->handler->reveal())
+        $routeResult = $this->prophesize(RouteResult::class);
+        $routeResult
+            ->process(
+                Argument::that([$this->request, 'reveal']),
+                Argument::that([$this->handler, 'reveal'])
+            )
             ->willReturn($this->response);
 
-        $routeResult = RouteResult::fromRoute(new Route('/', $routedMiddleware->reveal()));
-
-        $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
+        $this->request->getAttribute(RouteResult::class, false)->will([$routeResult, 'reveal']);
 
         $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 

--- a/test/MethodNotAllowedMiddlewareTest.php
+++ b/test/MethodNotAllowedMiddlewareTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router;
+
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\MethodNotAllowedMiddleware;
+use Zend\Expressive\Router\RouteResult;
+
+class MethodNotAllowedMiddlewareTest extends TestCase
+{
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
+
+    /** @var MethodNotAllowedMiddleware */
+    private $middleware;
+
+    /** @var ServerRequestInterface|ObjectProphecy */
+    private $request;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    public function setUp()
+    {
+        $this->handler = $this->prophesize(RequestHandlerInterface::class);
+        $this->request = $this->prophesize(ServerRequestInterface::class);
+        $this->response = $this->prophesize(ResponseInterface::class);
+        $this->middleware = new MethodNotAllowedMiddleware($this->response->reveal());
+    }
+
+    public function testDelegatesToHandlerIfNoRouteResultPresentInRequest()
+    {
+        $this->request->getAttribute(RouteResult::class, false)->willReturn(false);
+        $this->handler->handle(Argument::that([$this->request, 'reveal']))->will([$this->response, 'reveal']);
+
+        $this->response->withStatus(Argument::any())->shouldNotBeCalled();
+        $this->response->withHeader('Allow', Argument::any())->shouldNotBeCalled();
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $this->middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+    }
+
+    public function testDelegatesToHandlerIfRouteResultNotAMethodFailure()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->isMethodFailure()->willReturn(false);
+
+        $this->request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+        $this->handler->handle(Argument::that([$this->request, 'reveal']))->will([$this->response, 'reveal']);
+
+        $this->response->withStatus(Argument::any())->shouldNotBeCalled();
+        $this->response->withHeader('Allow', Argument::any())->shouldNotBeCalled();
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $this->middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+    }
+
+    public function testReturns405ResponseWithAllowHeaderIfResultDueToMethodFailure()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->isMethodFailure()->willReturn(true);
+        $result->getAllowedMethods()->willReturn(['GET', 'POST']);
+
+        $this->request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+        $this->handler->handle(Argument::that([$this->request, 'reveal']))->shouldNotBeCalled();
+
+        $this->response->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)->will([$this->response, 'reveal']);
+        $this->response->withHeader('Allow', 'GET,POST')->will([$this->response, 'reveal']);
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $this->middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+    }
+}

--- a/test/MethodNotAllowedMiddlewareTest.php
+++ b/test/MethodNotAllowedMiddlewareTest.php
@@ -44,7 +44,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
 
     public function testDelegatesToHandlerIfNoRouteResultPresentInRequest()
     {
-        $this->request->getAttribute(RouteResult::class, false)->willReturn(false);
+        $this->request->getAttribute(RouteResult::class)->willReturn(null);
         $this->handler->handle(Argument::that([$this->request, 'reveal']))->will([$this->response, 'reveal']);
 
         $this->response->withStatus(Argument::any())->shouldNotBeCalled();
@@ -61,7 +61,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
         $result = $this->prophesize(RouteResult::class);
         $result->isMethodFailure()->willReturn(false);
 
-        $this->request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+        $this->request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
         $this->handler->handle(Argument::that([$this->request, 'reveal']))->will([$this->response, 'reveal']);
 
         $this->response->withStatus(Argument::any())->shouldNotBeCalled();
@@ -79,7 +79,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
         $result->isMethodFailure()->willReturn(true);
         $result->getAllowedMethods()->willReturn(['GET', 'POST']);
 
-        $this->request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+        $this->request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
         $this->handler->handle(Argument::that([$this->request, 'reveal']))->shouldNotBeCalled();
 
         $this->response->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)->will([$this->response, 'reveal']);

--- a/test/MethodNotAllowedMiddlewareTest.php
+++ b/test/MethodNotAllowedMiddlewareTest.php
@@ -15,7 +15,6 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\MethodNotAllowedMiddleware;
 use Zend\Expressive\Router\RouteResult;

--- a/test/PathBasedRoutingMiddlewareTest.php
+++ b/test/PathBasedRoutingMiddlewareTest.php
@@ -44,10 +44,7 @@ class PathBasedRoutingMiddlewareTest extends TestCase
     {
         $this->router     = $this->prophesize(RouterInterface::class);
         $this->response   = $this->prophesize(ResponseInterface::class);
-        $this->middleware = new PathBasedRoutingMiddleware(
-            $this->router->reveal(),
-            $this->response->reveal()
-        );
+        $this->middleware = new PathBasedRoutingMiddleware($this->router->reveal());
 
         $this->request  = $this->prophesize(ServerRequestInterface::class);
         $this->handler = $this->prophesize(RequestHandlerInterface::class);

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -11,7 +11,10 @@ namespace ZendTest\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use TypeError;
 use Zend\Expressive\Router\Exception\InvalidArgumentException;
 use Zend\Expressive\Router\Route;
@@ -248,5 +251,17 @@ class RouteTest extends TestCase
         ));
 
         new Route('/test', $middleware);
+    }
+
+    public function testRouteIsMiddlewareAndProxiesToComposedMiddleware()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $handler = $this->prophesize(RequestHandlerInterface::class)->reveal();
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $middleware = $this->prophesize(MiddlewareInterface::class);
+        $middleware->process($request, $handler)->willReturn($response);
+
+        $route = new Route('/foo', $middleware->reveal());
+        $this->assertSame($response, $route->process($request, $handler));
     }
 }


### PR DESCRIPTION
This patch accomplishes several things.

First, it extracts the logic for producing a 405 response to new middleware, `Zend\Expressive\Router\MethodNotAllowedMiddleware`. This middleware checks for a route result that is due to method failure, and, in such a case, uses the composed response prototype. This change will allow users to substitute their own `MethodNotAllowedMiddleware`, allowing for templated solutions, or to omit it entirely, allowing fallback to the 404 handler.

Second, the `RouteMiddleware` was modified as follows:

- it no longer requires a response prototype
- it _always_ injects the route result as a request attribute
- it no longer produces a 405 response on its own

These changes mean the middleware does only what it says (routing).

Third, the `Route` class was modified to implement the PSR-15 `MiddlewareInterface`. When processed, it proxies to the composed middleware instance.

Fourth, the `RouteResult` was modified to implement the PSR-15 `MiddlewareInterface`. When processed, if it is a route failure, it delegates to the provided handler. If it is a successful route match, it proxies to the matched `Route` instance. The `getMatchedMiddleware()` method was removed, as it's essentially unnecessary; processing the route result accomplishes the same thing.

Fifth, the `DispatchMiddleware` was modified to process the `RouteResult` instance pulled from the request, instead of retrieving its composed middleware to process.