### PR TITLE
Imports `Implicit*Middleware` classes from zend-expressive

### DIFF
--- a/src/ImplicitHeadMiddleware.php
+++ b/src/ImplicitHeadMiddleware.php
@@ -46,7 +46,7 @@ class ImplicitHeadMiddleware implements MiddlewareInterface
     public const FORWARDED_HTTP_METHOD_ATTRIBUTE = 'forwarded_http_method';
 
     /**
-     * @var null|ResponseInterface
+     * @var ResponseInterface
      */
     private $response;
 

--- a/src/ImplicitHeadMiddleware.php
+++ b/src/ImplicitHeadMiddleware.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Handle implicit HEAD requests.
+ *
+ * Place this middleware after the routing middleware so that it can handle
+ * implicit HEAD requests: requests where HEAD is used, but the route does
+ * not explicitly handle that request method.
+ *
+ * When invoked, it will create an empty response with status code 200.
+ *
+ * You may optionally pass a response prototype to the constructor; when
+ * present, that instance will be returned instead.
+ *
+ * The middleware is only invoked in these specific conditions:
+ *
+ * - a HEAD request
+ * - with a `RouteResult` present
+ * - where the `RouteResult` contains a `Route` instance
+ * - and the `Route` instance defines implicit HEAD.
+ *
+ * In all other circumstances, it will return the result of the delegate.
+ *
+ * If the route instance supports GET requests, the middleware dispatches
+ * the next layer, but alters the request passed to use the GET method;
+ * it then provides an empty response body to the returned response.
+ */
+class ImplicitHeadMiddleware implements MiddlewareInterface
+{
+    public const FORWARDED_HTTP_METHOD_ATTRIBUTE = 'forwarded_http_method';
+
+    /**
+     * @var null|ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var callable
+     */
+    private $streamFactory;
+
+    /**
+     * @param ResponseInterface $response Response prototype to return for
+     *     implicit HEAD requests.
+     * @param callable $streamFactory A factory capable of returning an empty
+     *     StreamInterface instance to inject in a response.
+     */
+    public function __construct(ResponseInterface $response, callable $streamFactory)
+    {
+        $this->response = $response;
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * Handle an implicit HEAD request.
+     *
+     * If the route allows GET requests, dispatches as a GET request and
+     * resets the response body to be empty; otherwise, creates a new empty
+     * response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if ($request->getMethod() !== RequestMethod::METHOD_HEAD) {
+            return $handler->handle($request);
+        }
+
+        $result = $request->getAttribute(RouteResult::class);
+        if (! $result) {
+            return $handler->handle($request);
+        }
+
+        $route = $result->getMatchedRoute();
+        if (! $route || ! $route->implicitHead()) {
+            return $handler->handle($request);
+        }
+
+        if (! $route->allowsMethod(RequestMethod::METHOD_GET)) {
+            return $this->response;
+        }
+
+        $response = $handler->handle(
+            $request
+                ->withMethod(RequestMethod::METHOD_GET)
+                ->withAttribute(self::FORWARDED_HTTP_METHOD_ATTRIBUTE, RequestMethod::METHOD_HEAD)
+        );
+
+        /** @var StreamInterface $body */
+        $body = ($this->streamFactory)();
+        return $response->withBody($body);
+    }
+}

--- a/src/ImplicitOptionsMiddleware.php
+++ b/src/ImplicitOptionsMiddleware.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
+
+/**
+ * Handle implicit OPTIONS requests.
+ *
+ * Place this middleware after the routing middleware so that it can handle
+ * implicit OPTIONS requests: requests where OPTIONS is used, but the route
+ * does not explicitly handle that request method.
+ *
+ * When invoked, it will create a response with status code 200 and an Allow
+ * header that defines all accepted request methods.
+ *
+ * You may optionally pass a response prototype to the constructor; when
+ * present, that prototype will be used to create a new response with the
+ * Allow header.
+ *
+ * The middleware is only invoked in these specific conditions:
+ *
+ * - an OPTIONS request
+ * - with a `RouteResult` present
+ * - where the `RouteResult` contains a `Route` instance
+ * - and the `Route` instance defines implicit OPTIONS.
+ *
+ * In all other circumstances, it will return the result of the delegate.
+ */
+class ImplicitOptionsMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @param null|ResponseInterface $response Response prototype to use for
+     *     implicit OPTIONS requests.
+     */
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Handle an implicit OPTIONS request.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if ($request->getMethod() !== RequestMethod::METHOD_OPTIONS) {
+            return $handler->handle($request);
+        }
+
+        if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
+            return $handler->handle($request);
+        }
+
+        $route = $result->getMatchedRoute();
+        if (! $route || ! $route->implicitOptions()) {
+            return $handler->handle($request);
+        }
+
+        $methods = implode(',', $route->getAllowedMethods());
+        return $this->response->withHeader('Allow', $methods);
+    }
+}

--- a/test/ImplicitHeadMiddlewareTest.php
+++ b/test/ImplicitHeadMiddlewareTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\ImplicitHeadMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+class ImplicitHeadMiddlewareTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->stream = $this->prophesize(StreamInterface::class);
+        $streamFactory = function () {
+            return $this->stream->reveal();
+        };
+        $this->responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $this->middleware = new ImplicitHeadMiddleware(
+            $this->responsePrototype->reveal(),
+            $streamFactory
+        );
+    }
+
+    public function testReturnsResultOfHandlerOnNonHeadRequests()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
+            ->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenNoRouteResultPresentInRequest()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->willReturn(false);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
+            ->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenRouteResultDoesNotComposeRoute()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn(null);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
+            ->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenRouteSupportsHeadExplicitly()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
+            ->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsComposedResponseWhenPresentWhenRouteImplicitlySupportsHeadAndDoesNotSupportGet()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(true);
+        $route->allowsMethod(RequestMethod::METHOD_GET)->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->shouldNotBeCalled();
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($this->responsePrototype->reveal(), $result);
+    }
+
+    public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(true);
+        $route->allowsMethod(RequestMethod::METHOD_GET)->willReturn(true);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+        $request->withMethod(RequestMethod::METHOD_GET)->will([$request, 'reveal']);
+        $request
+            ->withAttribute(
+                ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE,
+                RequestMethod::METHOD_HEAD
+            )
+            ->will([$request, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->withBody($this->stream->reveal())->will([$response, 'reveal']);
+
+        $this->responsePrototype->withBody($this->stream->reveal())->shouldNotBeCalled();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler
+            ->handle(Argument::that([$request, 'reveal']))
+            ->will([$response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($response->reveal(), $result);
+    }
+}

--- a/test/ImplicitHeadMiddlewareTest.php
+++ b/test/ImplicitHeadMiddlewareTest.php
@@ -13,6 +13,7 @@ use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -23,6 +24,15 @@ use Zend\Expressive\Router\RouteResult;
 
 class ImplicitHeadMiddlewareTest extends TestCase
 {
+    /** @var ImplicitHeadMiddleware */
+    private $middleware;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $responsePrototype;
+
+    /** @var StreamInterface|ObjectProphecy */
+    private $stream;
+
     public function setUp()
     {
         $this->stream = $this->prophesize(StreamInterface::class);

--- a/test/ImplicitOptionsMiddlewareTest.php
+++ b/test/ImplicitOptionsMiddlewareTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\ImplicitOptionsMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+class ImplicitOptionsMiddlewareTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->responsePrototype = $this->prophesize(ResponseInterface::class);
+        $this->middleware = new ImplicitOptionsMiddleware($this->responsePrototype->reveal());
+    }
+
+    public function testNonOptionsRequestInvokesHandler()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+        $request->getAttribute(RouteResult::class, false)->shouldNotBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testMissingRouteResultInvokesHandler()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->willReturn(false);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testMissingRouteInRouteResultInvokesHandler()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn(null);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testOptionsRequestWhenRouteDefinesOptionsInvokesHandler()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitOptions()->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testInjectsAllowHeaderInResponseProvidedToConstructorDuringOptionsRequest()
+    {
+        $allowedMethods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
+
+        $route = $this->prophesize(Route::class);
+        $route->implicitOptions()->willReturn(true);
+        $route->getAllowedMethods()->willReturn($allowedMethods);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->shouldNotBeCalled();
+
+        $this->responsePrototype
+            ->withHeader('Allow', implode(',', $allowedMethods))
+            ->will([$this->responsePrototype, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($this->responsePrototype->reveal(), $result);
+    }
+}

--- a/test/ImplicitOptionsMiddlewareTest.php
+++ b/test/ImplicitOptionsMiddlewareTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Expressive\Router;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -21,6 +22,12 @@ use Zend\Expressive\Router\RouteResult;
 
 class ImplicitOptionsMiddlewareTest extends TestCase
 {
+    /** @var ImplicitOptionsMiddleware */
+    private $middleware;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $responsePrototype;
+
     public function setUp()
     {
         $this->responsePrototype = $this->prophesize(ResponseInterface::class);


### PR DESCRIPTION
Imports the `ImplicitHeadMiddleware` and `ImplicitOptionsMiddleware` classes from zend-expressive v2. Each is updated to no longer create a response, but instead require a response to its constructor. The `ImplicitHeadMiddleware` is also updated to require a callable for generating an empty stream instance to inject in the response returned from the handler.