### PR TITLE
Adds factories for all middleware and a ConfigProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
             "dev-master": "2.3.x-dev",
             "dev-develop": "2.4.x-dev",
             "dev-release-3.0.0": "3.0.x-dev"
+        },
+        "zf": {
+            "config-provider": "Zend\\Expressive\\Router\\ConfigProvider"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
+        "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0"
     },
@@ -36,6 +37,9 @@
         "zendframework/zend-expressive-zendrouter": "^3.0 to use the zend-router routing adapter"
     },
     "autoload": {
+        "files": [
+            "src/constants.php"
+        ],
         "psr-4": {
             "Zend\\Expressive\\Router\\": "src/"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f789a904f41e05d64ab14c617acccd7",
+    "content-hash": "45cb1b3c392c5b0db3e7a1595b485690",
     "packages": [
         {
             "name": "fig/http-message-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "71a4603107309bc9d7f38cf95158e7f5",
+    "content-hash": "1f789a904f41e05d64ab14c617acccd7",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -55,6 +55,55 @@
                 "response"
             ],
             "time": "2017-02-09T16:10:21+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+class ConfigProvider
+{
+    public function __invoke() : array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+        ];
+    }
+
+    public function getDependencies() : array
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            'factories' => [
+                Middleware\DispatchMiddleware::class         => Middleware\DispatchMiddlewareFactory::class,
+                Middleware\ImplicitHeadMiddleware::class     => Middleware\ImplicitHeadMiddlewareFactory::class,
+                Middleware\ImplicitOptionsMiddleware::class  => Middleware\ImplicitOptionsMiddlewareFactory::class,
+                Middleware\MethodNotAllowedMiddleware::class => Middleware\MethodNotAllowedMiddlewareFactory::class,
+                Middleware\PathBasedRoutingMiddleware::class => Middleware\PathBasedRoutingMiddlewareFactory::class,
+                Middleware\RouteMiddleware::class            => Middleware\RouteMiddlewareFactory::class,
+            ]
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+}

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Router\Exception;
 
+use Psr\Container\NotFoundExceptionInterface;
 use RuntimeException;
 
-class MissingDependencyException extends RuntimeException implements ExceptionInterface
+class MissingDependencyException extends RuntimeException implements
+    ExceptionInterface,
+    NotFoundExceptionInterface
 {
     public static function dependencyForService(string $dependency, string $service) : self
     {

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Exception;
+
+use RuntimeException;
+
+class MissingDependencyException extends RuntimeException implements ExceptionInterface
+{
+    public static function dependencyForService(string $dependency, string $service) : self
+    {
+        return new self(sprintf(
+            'Missing dependency "%s" for service "%2$s"; please make sure it is'
+            . ' registered in your container. Refer to the %2$s class and/or its'
+            . ' factory to determine what the service should return.',
+            $dependency,
+            $service
+        ));
+    }
+}

--- a/src/Middleware/DispatchMiddleware.php
+++ b/src/Middleware/DispatchMiddleware.php
@@ -7,12 +7,13 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive\Router\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
 
 /**
  * Default dispatch middleware.

--- a/src/Middleware/DispatchMiddlewareFactory.php
+++ b/src/Middleware/DispatchMiddlewareFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+
+class DispatchMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container) : DispatchMiddleware
+    {
+        return new DispatchMiddleware();
+    }
+}

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive\Router\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Psr\Http\Message\ResponseInterface;
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
 
 /**
  * Handle implicit HEAD requests.

--- a/src/Middleware/ImplicitHeadMiddlewareFactory.php
+++ b/src/Middleware/ImplicitHeadMiddlewareFactory.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+
+use const Zend\Expressive\Router\IMPLICIT_HEAD_MIDDLEWARE_RESPONSE;
+use const Zend\Expressive\Router\IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY;
+
+/**
+ * Create and return an ImplicitHeadMiddleware instance.
+ *
+ * This factory depends on two other services:
+ *
+ * - IMPLICIT_HEAD_MIDDLEWARE_RESPONSE, which should resolve to a
+ *   Psr\Http\Message\ResponseInterface instance.
+ * - IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY, which should resolve to a
+ *   callable that will produce an empty Psr\Http\Message\StreamInterface
+ *   instance.
+ */
+class ImplicitHeadMiddlewareFactory
+{
+    /**
+     * @throws MissingDependencyException if either the IMPLICIT_HEAD_MIDDLEWARE_RESPONSE
+     *     or IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY services are missing.
+     */
+    public function __invoke(ContainerInterface $container) : ImplicitHeadMiddleware
+    {
+        if (! $container->has(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE)) {
+            throw MissingDependencyException::dependencyForService(
+                IMPLICIT_HEAD_MIDDLEWARE_RESPONSE,
+                ImplicitHeadMiddleware::class
+            );
+        }
+
+        if (! $container->has(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY)) {
+            throw MissingDependencyException::dependencyForService(
+                IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY,
+                ImplicitHeadMiddleware::class
+            );
+        }
+
+        return new ImplicitHeadMiddleware(
+            $container->get(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE),
+            $container->get(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY)
+        );
+    }
+}

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive\Router\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/src/Middleware/ImplicitOptionsMiddlewareFactory.php
+++ b/src/Middleware/ImplicitOptionsMiddlewareFactory.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+
+use const Zend\Expressive\Router\IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE;
+
+/**
+ * Create and return an ImplicitOptionsMiddleware instance.
+ *
+ * This factory depends on one other service:
+ *
+ * - IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE, which should resolve to a
+ *     Psr\Http\Message\ResponseInterface instance.
+ */
+class ImplicitOptionsMiddlewareFactory
+{
+    /**
+     * @throws MissingDependencyException if the IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE
+     *     service is missing.
+     */
+    public function __invoke(ContainerInterface $container) : ImplicitOptionsMiddleware
+    {
+        if (! $container->has(IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE)) {
+            throw MissingDependencyException::dependencyForService(
+                IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE,
+                ImplicitOptionsMiddleware::class
+            );
+        }
+
+        return new ImplicitOptionsMiddleware(
+            $container->get(IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE)
+        );
+    }
+}

--- a/src/Middleware/MethodNotAllowedMiddleware.php
+++ b/src/Middleware/MethodNotAllowedMiddleware.php
@@ -7,13 +7,14 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive\Router\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
 
 /**
  * Emit a 405 Method Not Allowed response

--- a/src/Middleware/MethodNotAllowedMiddlewareFactory.php
+++ b/src/Middleware/MethodNotAllowedMiddlewareFactory.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+
+use const Zend\Expressive\Router\METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE;
+
+/**
+ * Create and return a MethodNotAllowedMiddleware instance.
+ *
+ * This factory depends on one other service:
+ *
+ * - METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE, which should resolve to a
+ *   Psr\Http\Message\ResponseInterface instance.
+ */
+class MethodNotAllowedMiddlewareFactory
+{
+    /**
+     * @throws MissingDependencyException if the METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE
+     *     service is missing.
+     */
+    public function __invoke(ContainerInterface $container) : MethodNotAllowedMiddleware
+    {
+        if (! $container->has(METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE)) {
+            throw MissingDependencyException::dependencyForService(
+                METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE,
+                MethodNotAllowedMiddleware::class
+            );
+        }
+
+        return new MethodNotAllowedMiddleware(
+            $container->get(METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE)
+        );
+    }
+}

--- a/src/Middleware/PathBasedRoutingMiddleware.php
+++ b/src/Middleware/PathBasedRoutingMiddleware.php
@@ -7,9 +7,11 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive\Router\Middleware;
 
 use Psr\Http\Server\MiddlewareInterface;
+use Zend\Expressive\Router\Exception;
+use Zend\Expressive\Router\Route;
 
 /**
  * Routing middleware for path-based routes.

--- a/src/Middleware/PathBasedRoutingMiddlewareFactory.php
+++ b/src/Middleware/PathBasedRoutingMiddlewareFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\RouterInterface;
+
+/**
+ * Create and return a PathBasedRoutingMiddleware instance.
+ *
+ * This factory depends on one other service:
+ *
+ * - Zend\Expressive\Router\RouterInterface, which should resolve to
+ *   a class implementing that interface.
+ */
+class PathBasedRoutingMiddlewareFactory
+{
+    /**
+     * @throws MissingDependencyException if the RouterInterface service is
+     *     missing.
+     */
+    public function __invoke(ContainerInterface $container) : PathBasedRoutingMiddleware
+    {
+        if (! $container->has(RouterInterface::class)) {
+            throw MissingDependencyException::dependencyForService(
+                RouterInterface::class,
+                PathBasedRoutingMiddleware::class
+            );
+        }
+
+        return new PathBasedRoutingMiddleware($container->get(RouterInterface::class));
+    }
+}

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -7,12 +7,14 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive\Router\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 /**
  * Default routing middleware.

--- a/src/Middleware/RouteMiddlewareFactory.php
+++ b/src/Middleware/RouteMiddlewareFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\RouterInterface;
+
+/**
+ * Create and return a RouteMiddleware instance.
+ *
+ * This factory depends on one other service:
+ *
+ * - Zend\Expressive\Router\RouterInterface, which should resolve to
+ *   a class implementing that interface.
+ */
+class RouteMiddlewareFactory
+{
+    /**
+     * @throws MissingDependencyException if the RouterInterface service is
+     *     missing.
+     */
+    public function __invoke(ContainerInterface $container) : RouteMiddleware
+    {
+        if (! $container->has(RouterInterface::class)) {
+            throw MissingDependencyException::dependencyForService(
+                RouterInterface::class,
+                RouteMiddleware::class
+            );
+        }
+
+        return new RouteMiddleware($container->get(RouterInterface::class));
+    }
+}

--- a/src/constants.php
+++ b/src/constants.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Router;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Service name that will produce a ResponseInterface instance for use with
+ * Middleware\ImplicitHeadMiddleware.
+ *
+ * @var string
+ */
+const IMPLICIT_HEAD_MIDDLEWARE_RESPONSE = 'IMPLICIT_HEAD_MIDDLEWARE_RESPONSE';
+
+/**
+ * Service name that will produce a factory capable of producing a
+ * StreamInterface instance for use with Middleware\ImplicitHeadMiddleware.
+ *
+ * @var string
+ */
+const IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY = 'IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY';
+
+/**
+ * Service name that will produce a ResponseInterface instance for use with
+ * Middleware\ImplicitOptionsMiddleware.
+ *
+ * @var string
+ */
+const IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE = 'IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE';
+
+/**
+ * Service name that will produce a ResponseInterface instance for use with
+ * Middleware\MethodNotAllowedMiddleware.
+ *
+ * @var string
+ */
+const METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE = 'METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE';

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Router\ConfigProvider;
+use Zend\Expressive\Router\Middleware;
+
+class ConfigProviderTest extends TestCase
+{
+    public function testProviderProvidesFactoriesForAllMiddleware()
+    {
+        $provider = new ConfigProvider();
+        $config = $provider();
+
+        $this->assertTrue(isset($config['dependencies']['factories']));
+        $factories = $config['dependencies']['factories'];
+        $this->assertArrayHasKey(Middleware\DispatchMiddleware::class, $factories);
+        $this->assertArrayHasKey(Middleware\ImplicitHeadMiddleware::class, $factories);
+        $this->assertArrayHasKey(Middleware\ImplicitOptionsMiddleware::class, $factories);
+        $this->assertArrayHasKey(Middleware\MethodNotAllowedMiddleware::class, $factories);
+        $this->assertArrayHasKey(Middleware\PathBasedRoutingMiddleware::class, $factories);
+        $this->assertArrayHasKey(Middleware\RouteMiddleware::class, $factories);
+    }
+}

--- a/test/Middleware/DispatchMiddlewareFactoryTest.php
+++ b/test/Middleware/DispatchMiddlewareFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Middleware\DispatchMiddleware;
+use Zend\Expressive\Router\Middleware\DispatchMiddlewareFactory;
+
+class DispatchMiddlewareFactoryTest extends TestCase
+{
+    public function testFactoryProducesDispatchMiddleware()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new DispatchMiddlewareFactory();
+        $middleware = $factory($container);
+        $this->assertInstanceOf(DispatchMiddleware::class, $middleware);
+    }
+}

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -15,7 +15,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\Router\DispatchMiddleware;
+use Zend\Expressive\Router\Middleware\DispatchMiddleware;
 use Zend\Expressive\Router\RouteResult;
 
 class DispatchMiddlewareTest extends TestCase

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Router\Middleware\ImplicitHeadMiddlewareFactory;
+
+use const Zend\Expressive\Router\IMPLICIT_HEAD_MIDDLEWARE_RESPONSE;
+use const Zend\Expressive\Router\IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY;
+
+class ImplicitHeadMiddlewareFactoryTest extends TestCase
+{
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var ImplicitHeadMiddlewareFactory */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new ImplicitHeadMiddlewareFactory();
+    }
+
+    public function testFactoryRaisesExceptionIfResponseServiceIsMissing()
+    {
+        $this->container->has(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE)->willReturn(false);
+        $this->container->has(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY)->shouldNotBeCalled();
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
+    public function testFactoryRaisesExceptionIfStreamFactoryServiceIsMissing()
+    {
+        $this->container->has(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE)->willReturn(true);
+        $this->container->has(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY)->willReturn(false);
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
+    public function testFactoryProducesImplicitHeadMiddlewareWhenAllDependenciesPresent()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $factory = function () {
+        };
+
+        $this->container->has(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE)->willReturn(true);
+        $this->container->has(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY)->willReturn(true);
+
+        $this->container->get(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE)->willReturn($response);
+        $this->container->get(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY)->willReturn($factory);
+
+        $middleware = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(ImplicitHeadMiddleware::class, $middleware);
+    }
+}

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
@@ -18,7 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\Router\ImplicitHeadMiddleware;
+use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 

--- a/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
+use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddlewareFactory;
+
+use const Zend\Expressive\Router\IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE;
+
+class ImplicitOptionsMiddlewareFactoryTest extends TestCase
+{
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var ImplicitOptionsMiddlewareFactory */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new ImplicitOptionsMiddlewareFactory();
+    }
+
+    public function testFactoryRaisesExceptionIfResponseServiceIsMissing()
+    {
+        $this->container->has(IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE)->willReturn(false);
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
+    public function testFactoryProducesImplicitOptionsMiddlewareWhenAllDependenciesPresent()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $this->container->has(IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE)->willReturn(true);
+        $this->container->get(IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE)->willReturn($response);
+
+        $middleware = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(ImplicitOptionsMiddleware::class, $middleware);
+    }
+}

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
@@ -16,7 +16,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\Router\ImplicitOptionsMiddleware;
+use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 

--- a/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
+use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddlewareFactory;
+
+use const Zend\Expressive\Router\METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE;
+
+class MethodNotAllowedMiddlewareFactoryTest extends TestCase
+{
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var MethodNotAllowedMiddlewareFactory */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new MethodNotAllowedMiddlewareFactory();
+    }
+
+    public function testFactoryRaisesExceptionIfResponseServiceIsMissing()
+    {
+        $this->container->has(METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE)->willReturn(false);
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
+    public function testFactoryProducesMethodNotAllowedMiddlewareWhenAllDependenciesPresent()
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $this->container->has(METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE)->willReturn(true);
+        $this->container->get(METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE)->willReturn($response);
+
+        $middleware = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(MethodNotAllowedMiddleware::class, $middleware);
+    }
+}

--- a/test/Middleware/MethodNotAllowedMiddlewareTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +16,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\Router\MethodNotAllowedMiddleware;
+use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
 use Zend\Expressive\Router\RouteResult;
 
 class MethodNotAllowedMiddlewareTest extends TestCase

--- a/test/Middleware/PathBasedRoutingMiddlewareFactoryTest.php
+++ b/test/Middleware/PathBasedRoutingMiddlewareFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
+use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddlewareFactory;
+use Zend\Expressive\Router\RouterInterface;
+
+class PathBasedRoutingMiddlewareFactoryTest extends TestCase
+{
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var PathBasedRoutingMiddlewareFactory */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new PathBasedRoutingMiddlewareFactory();
+    }
+
+    public function testFactoryRaisesExceptionIfRouterServiceIsMissing()
+    {
+        $this->container->has(RouterInterface::class)->willReturn(false);
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
+    public function testFactoryProducesPathBasedRoutingMiddlewareWhenAllDependenciesPresent()
+    {
+        $router = $this->prophesize(RouterInterface::class)->reveal();
+        $this->container->has(RouterInterface::class)->willReturn(true);
+        $this->container->get(RouterInterface::class)->willReturn($router);
+
+        $middleware = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(PathBasedRoutingMiddleware::class, $middleware);
+    }
+}

--- a/test/Middleware/PathBasedRoutingMiddlewareTest.php
+++ b/test/Middleware/PathBasedRoutingMiddlewareTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -18,7 +18,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TypeError;
 use Zend\Expressive\Router\Exception;
-use Zend\Expressive\Router\PathBasedRoutingMiddleware;
+use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;

--- a/test/Middleware/RouteMiddlewareFactoryTest.php
+++ b/test/Middleware/RouteMiddlewareFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\Middleware\RouteMiddleware;
+use Zend\Expressive\Router\Middleware\RouteMiddlewareFactory;
+use Zend\Expressive\Router\RouterInterface;
+
+class RouteMiddlewareFactoryTest extends TestCase
+{
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var RouteMiddlewareFactory */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new RouteMiddlewareFactory();
+    }
+
+    public function testFactoryRaisesExceptionIfRouterServiceIsMissing()
+    {
+        $this->container->has(RouterInterface::class)->willReturn(false);
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
+    public function testFactoryProducesRouteMiddlewareWhenAllDependenciesPresent()
+    {
+        $router = $this->prophesize(RouterInterface::class)->reveal();
+        $this->container->has(RouterInterface::class)->willReturn(true);
+        $this->container->get(RouterInterface::class)->willReturn($router);
+
+        $middleware = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(RouteMiddleware::class, $middleware);
+    }
+}

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit\Framework\TestCase;
@@ -16,8 +16,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\Middleware\RouteMiddleware;
 use Zend\Expressive\Router\Route;
-use Zend\Expressive\Router\RouteMiddleware;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
 


### PR DESCRIPTION
This patch accomplishes three things:

- It moves all middleware into a subnamespace, `Zend\Expressive\Router\Middleware`. This is done due to the large number of middleware now provided (six!), and the fact that each will have a factory.
- Adds factories for all provided middleware. In some cases, these depend on virtual services (e.g., response prototypes, callable factories). In those cases, per discussion in zendframework/zend-expressive-skeleton#220, I've added package-level constants, and have the factories look for services named after those constant values, raising an exception if missing.
- Adds a `ConfigProvider` class that defines factory entries for each middleware, and registers the provider in the package.