### PR TITLE
Move middleware into subnamespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#54](https://github.com/zendframework/zend-expressive-router/pull/54) adds
+  the middleware `Zend\Expressive\Router\Middleware\DispatchMiddleware` and
+  `Zend\Expressive\Router\Middleware\RouteMiddleware`. These are the same as the
+  versions shipped in 2.3.0, but under a new namespace.
 
 ### Changed
 
@@ -24,6 +27,12 @@ All notable changes to this project will be documented in this file, in reverse 
   deprecates passing non-MiddlewareInterface instances to the constructor of
   `Zend\Expressive\Route`. The class now triggers a deprecation notice when this
   occurs, indicating the changes the developer needs to make.
+
+- [#54](https://github.com/zendframework/zend-expressive-router/pull/54)
+  deprecates the middleware `Zend\Expressive\Router\DispatchMiddleware` and
+  `Zend\Expressive\Router\RouteMiddleware`. The final versions in the v3 release
+  will be under the `Zend\Expressive\Router\Middleware` namespace; please use
+  those instead.
 
 ### Removed
 

--- a/src/DispatchMiddleware.php
+++ b/src/DispatchMiddleware.php
@@ -7,56 +7,10 @@
 
 namespace Zend\Expressive\Router;
 
-use Interop\Http\Middleware\ServerMiddlewareInterface as LegacyLegacyMiddlewareInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as LegacyMiddlewareInterface;
-use Interop\Http\Server\MiddlewareInterface as InteropMiddlewareInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
-
 /**
- * Default dispatch middleware.
- *
- * Checks for a composed route result in the request. If none is provided,
- * delegates to the next middleware.
- *
- * Otherwise, it pulls the middleware from the route result. If the middleware
- * is not http-interop middleware, it raises an exception. This means that
- * this middleware is incompatible with routes that store non-http-interop
- * middleware instances! Make certain you only provide middleware instances
- * to your router when using this middleware.
+ * @deprecated since 2.4.0; to remove in 3.0.0. Use
+ *     Zend\Expressive\Router\Middleware\DispatchMiddleware instead.
  */
-class DispatchMiddleware implements MiddlewareInterface
+class DispatchMiddleware extends Middleware\DispatchMiddleware
 {
-    /**
-     * @param ServerRequestInterface $request
-     * @param HandlerInterface $handler
-     * @return ResponseInterface
-     */
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
-    {
-        $routeResult = $request->getAttribute(RouteResult::class, false);
-        if (! $routeResult) {
-            return $handler->{HANDLER_METHOD}($request);
-        }
-
-        $middleware = $routeResult->getMatchedMiddleware();
-
-        if (! $middleware instanceof LegacyLegacyMiddlewareInterface
-            && ! $middleware instanceof LegacyMiddlewareInterface
-            && ! $middleware instanceof InteropMiddlewareInterface
-        ) {
-            throw new Exception\RuntimeException(sprintf(
-                'Unknown middleware type stored in route; %s expects an http-interop'
-                . ' middleware instance; received %s',
-                __CLASS__,
-                is_object($middleware) ? get_class($middleware) : gettype($middleware)
-            ));
-        }
-
-        return $middleware->process($request, $handler);
-    }
 }

--- a/src/Middleware/DispatchMiddleware.php
+++ b/src/Middleware/DispatchMiddleware.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Interop\Http\Middleware\ServerMiddlewareInterface as LegacyLegacyMiddlewareInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as LegacyMiddlewareInterface;
+use Interop\Http\Server\MiddlewareInterface as InteropMiddlewareInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Expressive\Router\Exception;
+use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+/**
+ * Default dispatch middleware.
+ *
+ * Checks for a composed route result in the request. If none is provided,
+ * delegates to the next middleware.
+ *
+ * Otherwise, it pulls the middleware from the route result. If the middleware
+ * is not http-interop middleware, it raises an exception. This means that
+ * this middleware is incompatible with routes that store non-http-interop
+ * middleware instances! Make certain you only provide middleware instances
+ * to your router when using this middleware.
+ */
+class DispatchMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param HandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    {
+        $routeResult = $request->getAttribute(RouteResult::class, false);
+        if (! $routeResult) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        $middleware = $routeResult->getMatchedMiddleware();
+
+        if (! $middleware instanceof LegacyLegacyMiddlewareInterface
+            && ! $middleware instanceof LegacyMiddlewareInterface
+            && ! $middleware instanceof InteropMiddlewareInterface
+        ) {
+            throw new Exception\RuntimeException(sprintf(
+                'Unknown middleware type stored in route; %s expects an http-interop'
+                . ' middleware instance; received %s',
+                __CLASS__,
+                is_object($middleware) ? get_class($middleware) : gettype($middleware)
+            ));
+        }
+
+        return $middleware->process($request, $handler);
+    }
+}

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+/**
+ * Default routing middleware.
+ *
+ * Uses the composed router to match against the incoming request.
+ *
+ * When routing failure occurs, if the failure is due to HTTP method, uses
+ * the composed response prototype to generate a 405 response; otherwise,
+ * it delegates to the next middleware.
+ *
+ * If routing succeeds, injects the route result into the request (under the
+ * RouteResult class name), as well as any matched parameters, before
+ * delegating to the next middleware.
+ */
+class RouteMiddleware implements MiddlewareInterface
+{
+    /**
+     * Response prototype for 405 responses.
+     *
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @param RouterInterface $router
+     * @param ResponseInterface $responsePrototype
+     */
+    public function __construct(RouterInterface $router, ResponseInterface $responsePrototype)
+    {
+        $this->router = $router;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param HandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    {
+        $result = $this->router->match($request);
+
+        if ($result->isFailure()) {
+            if ($result->isMethodFailure()) {
+                return $this->responsePrototype->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
+                    ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
+            }
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        // Inject the actual route result, as well as individual matched parameters.
+        $request = $request->withAttribute(RouteResult::class, $result);
+        foreach ($result->getMatchedParams() as $param => $value) {
+            $request = $request->withAttribute($param, $value);
+        }
+
+        return $handler->{HANDLER_METHOD}($request);
+    }
+}

--- a/src/RouteMiddleware.php
+++ b/src/RouteMiddleware.php
@@ -7,76 +7,10 @@
 
 namespace Zend\Expressive\Router;
 
-use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\Router\RouterInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
-
 /**
- * Default routing middleware.
- *
- * Uses the composed router to match against the incoming request.
- *
- * When routing failure occurs, if the failure is due to HTTP method, uses
- * the composed response prototype to generate a 405 response; otherwise,
- * it delegates to the next middleware.
- *
- * If routing succeeds, injects the route result into the request (under the
- * RouteResult class name), as well as any matched parameters, before
- * delegating to the next middleware.
+ * @deprecated since 2.4.0; to remove in 3.0.0. Use
+ *     Zend\Expressive\Router\Middleware\RouteMiddleware instead.
  */
-class RouteMiddleware implements MiddlewareInterface
+class RouteMiddleware extends Middleware\RouteMiddleware
 {
-    /**
-     * Response prototype for 405 responses.
-     *
-     * @var ResponseInterface
-     */
-    private $responsePrototype;
-
-    /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @param RouterInterface $router
-     * @param ResponseInterface $responsePrototype
-     */
-    public function __construct(RouterInterface $router, ResponseInterface $responsePrototype)
-    {
-        $this->router = $router;
-        $this->responsePrototype = $responsePrototype;
-    }
-
-    /**
-     * @param ServerRequestInterface $request
-     * @param HandlerInterface $handler
-     * @return ResponseInterface
-     */
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
-    {
-        $result = $this->router->match($request);
-
-        if ($result->isFailure()) {
-            if ($result->isMethodFailure()) {
-                return $this->responsePrototype->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
-                    ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
-            }
-            return $handler->{HANDLER_METHOD}($request);
-        }
-
-        // Inject the actual route result, as well as individual matched parameters.
-        $request = $request->withAttribute(RouteResult::class, $result);
-        foreach ($result->getMatchedParams() as $param => $value) {
-            $request = $request->withAttribute($param, $value);
-        }
-
-        return $handler->{HANDLER_METHOD}($request);
-    }
 }

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -5,7 +5,7 @@
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -5,7 +5,7 @@
  * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
  */
 
-namespace ZendTest\Expressive\Router;
+namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Per the [migration roadmap](https://discourse.zendframework.com/t/roadmap-expressive-2-2/504), all middleware shipped by this component need to be in a subnamespace, as that's where they will be in version 3.

This patch moves the route and dispatch middleware to the `Zend\Expressive\Router\Middleware` namespace, and then creates extensions under the original names that are immediately deprecated.