### PR TITLE
Imports ImplicitHead, ImplicitOptions Middleware from zend-expressive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --no-scripts"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
@@ -19,7 +19,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
+        - LEGACY_DEPS="phpunit/phpunit symfony/console symfony/finder"
     - php: 5.6
       env:
         - DEPS=latest
@@ -29,7 +29,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
+        - LEGACY_DEPS="phpunit/phpunit symfony/console symfony/finder"
     - php: 7
       env:
         - DEPS=latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ All notable changes to this project will be documented in this file, in reverse 
   will be under the `Zend\Expressive\Router\Middleware` namespace; please use
   those instead.
 
+- [#55](https://github.com/zendframework/zend-expressive-router/pull/55)
+  deprecates two methods in `Zend\Expressive\Router\Route`:
+
+  - `implicitHead()`
+  - `implicitOptions()`
+
+  Starting in 3.0.0, implementations will need to return route result failures
+  that include all allowed methods when matching `HEAD` or `OPTIONS` implicitly.
+
 ### Removed
 
 - Nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file, in reverse 
   `Zend\Expressive\Router\Middleware\RouteMiddleware`. These are the same as the
   versions shipped in 2.3.0, but under a new namespace.
 
+- [#55](https://github.com/zendframework/zend-expressive-router/pull/55) adds
+  `Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware`. It is imported
+  from zend-expressive, and implements the same functionality.
+
+- [#55](https://github.com/zendframework/zend-expressive-router/pull/55) adds
+  `Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware`. It is imported
+  from zend-expressive, and implements the same functionality.
+
 ### Changed
 
 - Nothing.

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -105,6 +105,6 @@ class ImplicitHeadMiddleware implements MiddlewareInterface
         $streamFactory = $this->streamFactory;
         /** @var StreamInterface $body */
         $body = $streamFactory();
-        return $this->response->withBody($body);
+        return $response->withBody($body);
     }
 }

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+/**
+ * Handle implicit HEAD requests.
+ *
+ * Place this middleware after the routing middleware so that it can handle
+ * implicit HEAD requests: requests where HEAD is used, but the route does
+ * not explicitly handle that request method.
+ *
+ * When invoked, it will create an empty response with status code 200.
+ *
+ * You may optionally pass a response prototype to the constructor; when
+ * present, that instance will be returned instead.
+ *
+ * The middleware is only invoked in these specific conditions:
+ *
+ * - a HEAD request
+ * - with a `RouteResult` present
+ * - where the `RouteResult` contains a `Route` instance
+ * - and the `Route` instance defines implicit HEAD.
+ *
+ * In all other circumstances, it will return the result of the delegate.
+ *
+ * If the route instance supports GET requests, the middleware dispatches
+ * the next layer, but alters the request passed to use the GET method;
+ * it then provides an empty response body to the returned response.
+ */
+class ImplicitHeadMiddleware implements MiddlewareInterface
+{
+    const FORWARDED_HTTP_METHOD_ATTRIBUTE = 'forwarded_http_method';
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var callable
+     */
+    private $streamFactory;
+
+    /**
+     * @param callable $streamFactory A factory capable of returning an empty
+     *     StreamInterface instance to inject in a response.
+     */
+    public function __construct(RouterInterface $router, callable $streamFactory)
+    {
+        $this->router = $router;
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * Handle an implicit HEAD request.
+     *
+     * If the route allows GET requests, dispatches as a GET request and
+     * resets the response body to be empty; otherwise, creates a new empty
+     * response.
+     *
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        if ($request->getMethod() !== RequestMethod::METHOD_HEAD) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        $result = $request->getAttribute(RouteResult::class);
+        if (! $result) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        if ($result->getMatchedRoute()) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        $routeResult = $this->router->match($request->withMethod(RequestMethod::METHOD_GET));
+        if ($routeResult->isFailure()) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        $response = $handler->{HANDLER_METHOD}(
+            $request
+                ->withAttribute(RouteResult::class, $routeResult)
+                ->withMethod(RequestMethod::METHOD_GET)
+                ->withAttribute(self::FORWARDED_HTTP_METHOD_ATTRIBUTE, RequestMethod::METHOD_HEAD)
+        );
+
+        $streamFactory = $this->streamFactory;
+        /** @var StreamInterface $body */
+        $body = $streamFactory();
+        return $response->withBody($body);
+    }
+}

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -67,12 +67,13 @@ class ImplicitOptionsMiddleware implements MiddlewareInterface
             return $handler->{HANDLER_METHOD}($request);
         }
 
-        if ($result->getMatchedRoute()) {
+        $route = $result->getMatchedRoute();
+        if (! $route || ! $route->implicitOptions()) {
             return $handler->{HANDLER_METHOD}($request);
         }
 
-        $allowedMethods = $result->getAllowedMethods();
+        $methods = implode(',', $route->getAllowedMethods());
 
-        return $this->response->withHeader('Allow', implode(',', $allowedMethods));
+        return $this->response->withHeader('Allow', $methods);
     }
 }

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+/**
+ * Handle implicit OPTIONS requests.
+ *
+ * Place this middleware after the routing middleware so that it can handle
+ * implicit OPTIONS requests: requests where OPTIONS is used, but the route
+ * does not explicitly handle that request method.
+ *
+ * When invoked, it will create a response with status code 200 and an Allow
+ * header that defines all accepted request methods.
+ *
+ * You may optionally pass a response prototype to the constructor; when
+ * present, that prototype will be used to create a new response with the
+ * Allow header.
+ *
+ * The middleware is only invoked in these specific conditions:
+ *
+ * - an OPTIONS request
+ * - with a `RouteResult` present
+ * - where the `RouteResult` contains a `Route` instance
+ * - and the `Route` instance defines implicit OPTIONS.
+ *
+ * In all other circumstances, it will return the result of the delegate.
+ */
+class ImplicitOptionsMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Handle an implicit OPTIONS request.
+     *
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
+    {
+        if ($request->getMethod() !== RequestMethod::METHOD_OPTIONS) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        $result = $request->getAttribute(RouteResult::class);
+        if (! $result) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        if ($result->getMatchedRoute()) {
+            return $handler->{HANDLER_METHOD}($request);
+        }
+
+        $allowedMethods = $result->getAllowedMethods();
+
+        return $this->response->withHeader('Allow', implode(',', $allowedMethods));
+    }
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -208,6 +208,9 @@ class Route
     /**
      * Whether or not HEAD support is implicit (i.e., not explicitly specified)
      *
+     * @deprecated Since 2.4.0; to be removed in 3.0.0. Router implementations
+     *     will be expected to return route failures for HEAD requests that
+     *     contain a full list of allowed methods.
      * @return bool
      */
     public function implicitHead()
@@ -218,6 +221,9 @@ class Route
     /**
      * Whether or not OPTIONS support is implicit (i.e., not explicitly specified)
      *
+     * @deprecated Since 2.4.0; to be removed in 3.0.0. Router implementations
+     *     will be expected to return route failures for OPTIONS requests that
+     *     contain a full list of allowed methods.
      * @return bool
      */
     public function implicitOptions()

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class ImplicitHeadMiddlewareTest extends TestCase
+{
+    /** @var ImplicitHeadMiddleware */
+    private $middleware;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    /** @var RouterInterface|ObjectProphecy */
+    private $router;
+
+    /** @var StreamInterface|ObjectProphecy */
+    private $stream;
+
+    public function setUp()
+    {
+        $this->router = $this->prophesize(RouterInterface::class);
+        $this->stream = $this->prophesize(StreamInterface::class);
+
+        $streamFactory = function () {
+            return $this->stream->reveal();
+        };
+
+        $this->middleware = new ImplicitHeadMiddleware($this->router->reveal(), $streamFactory);
+        $this->response = $this->prophesize(ResponseInterface::class);
+    }
+
+    public function testReturnsResultOfHandlerOnNonHeadRequests()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->will([$this->response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenNoRouteResultPresentInRequest()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->willReturn(null);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->will([$this->response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenRouteSupportsHeadExplicitly()
+    {
+        $route = $this->prophesize(Route::class);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->will([$this->response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenRouteDoesNotExplicitlySupportHeadAndDoesNotSupportGet()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn(false);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+        $request->withMethod(RequestMethod::METHOD_GET)->will([$request, 'reveal']);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(true);
+
+        $this->router->match($request)->will([$result, 'reveal']);
+        $request->withAttribute(RouteResult::class, $result)->will([$request, 'reveal']);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->will([$this->response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($this->response->reveal(), $result);
+    }
+
+    public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn(false);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+        $request->withMethod(RequestMethod::METHOD_GET)->will([$request, 'reveal']);
+        $request
+            ->withAttribute(
+                ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE,
+                RequestMethod::METHOD_HEAD
+            )
+            ->will([$request, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->withBody($this->stream->reveal())->will([$response, 'reveal']);
+
+        $route = $this->prophesize(Route::class);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(false);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request->withAttribute(RouteResult::class, $result->reveal())->will([$request, 'reveal']);
+
+        $this->router->match($request)->will([$result, 'reveal']);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler
+            ->{HANDLER_METHOD}(Argument::that([$request, 'reveal']))
+            ->will([$response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+
+        $this->assertSame($response->reveal(), $result);
+    }
+}

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-router for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-router/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Router\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as RequestHandlerInterface;
+use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
+
+class ImplicitOptionsMiddlewareTest extends TestCase
+{
+    /** @var ImplicitOptionsMiddleware */
+    private $middleware;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    public function setUp()
+    {
+        $this->response = $this->prophesize(ResponseInterface::class);
+        $this->middleware = new ImplicitOptionsMiddleware($this->response->reveal());
+    }
+
+    public function testNonOptionsRequestInvokesHandler()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+        $request->getAttribute(RouteResult::class, false)->shouldNotBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testMissingRouteResultInvokesHandler()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class)->willReturn(null);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenRouteSupportsOptionsExplicitly()
+    {
+        $route = $this->prophesize(Route::class);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($response, $result);
+    }
+
+    public function testInjectsAllowHeaderInResponseProvidedToConstructorDuringOptionsRequest()
+    {
+        $allowedMethods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getAllowedMethods()->willReturn($allowedMethods);
+        $result->getMatchedRoute()->willReturn(false);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled();
+
+        $this->response
+            ->withHeader('Allow', implode(',', $allowedMethods))
+            ->will([$this->response, 'reveal']);
+
+        $result = $this->middleware->process($request->reveal(), $handler->reveal());
+        $this->assertSame($this->response->reveal(), $result);
+    }
+}


### PR DESCRIPTION
Per the [Expressive 2.2.  roadmap](https://discourse.zendframework.com/t/roadmap-expressive-2-2/504), this patch imports the `ImplicitHeadMiddleware` and `ImplicitOptionsMiddleware` from zend-expressive v2, and places them in the `Zend\Expressive\Router\Middleware` namespace. They have been updated to allow compatibility with any version of http-interop middleware, via the webimpress/http-middleware-compatibility package (which was already a requirement).

This patch updates `ImplicitHeadMiddleware` to optionally allow passing a second argument representing a PHP callable capable of producing a PSR-7 `StreamInterface` instance.

Finally, it deprecates the `implicitHead()` and `implicitOptions()` methods of the `Route` class, as they are removed in version 3.