### PR TITLE
Mark deprecations for version 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.4.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- [#56](https://github.com/zendframework/zend-expressive-router/pull/56)
+  deprecates the method `Zend\Expressive\RouteResult::getMatchedMiddleware()`,
+  as it will be removed in version 3. If you need access to the middleware,
+  use `getMatchedRoute()->getMiddleware()`. (In version 3, the `RouteResult`
+  _is_ middleware, and will proxy to it.)
+
+- [#56](https://github.com/zendframework/zend-expressive-router/pull/56)
+  deprecates passing non-MiddlewareInterface instances to the constructor of
+  `Zend\Expressive\Route`. The class now triggers a deprecation notice when this
+  occurs, indicating the changes the developer needs to make.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.3.0 - 2018-02-01
 
 ### Added

--- a/src/Route.php
+++ b/src/Route.php
@@ -82,6 +82,15 @@ class Route
             throw new Exception\InvalidArgumentException('Invalid path; must be a string');
         }
 
+        if (! $middleware instanceof MiddlewareInterface) {
+            trigger_error(sprintf(
+                '%1$s will not accept anything other than objects implementing the MiddlewareInterface'
+                . ' starting in version 3.0.0. Please update your code to create %1$s instances'
+                . ' using MiddlewareInterface instances.',
+                __CLASS__
+            ), E_USER_DEPRECATED);
+        }
+
         if (! is_callable($middleware)
             && ! $middleware instanceof MiddlewareInterface
             && ! is_string($middleware)

--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -147,6 +147,10 @@ class RouteResult
     /**
      * Retrieve the matched middleware, if possible.
      *
+     * @deprecated since 2.4.0; to remove in 3.0.0. Retrieve using
+     *     `getMatchedRoute()->getMiddleware()` if access is required. In version 3,
+     *     RouteResult will implement the PSR-15 MiddlewareInterface, and proxy to the
+     *     matched middleware if present, and to the handler argument otherwise.
      * @return false|callable|string|MiddlewareInterface|array Returns false if
      *     the result represents a failure; otherwise, a callable, a string
      *     service name, a MiddlewareInterface instance, or array of any of

--- a/test/DispatchMiddlewareTest.php
+++ b/test/DispatchMiddlewareTest.php
@@ -22,6 +22,9 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class DispatchMiddlewareTest extends TestCase
 {
+    /** @var null|callable */
+    private $errorHandler;
+
     /** @var HandlerInterface|ObjectProphecy */
     private $handler;
 
@@ -33,6 +36,14 @@ class DispatchMiddlewareTest extends TestCase
         $this->request    = $this->prophesize(ServerRequestInterface::class);
         $this->handler    = $this->prophesize(HandlerInterface::class);
         $this->middleware = new DispatchMiddleware();
+    }
+
+    public function tearDown()
+    {
+        if ($this->errorHandler) {
+            restore_error_handler();
+            $this->errorHandler = null;
+        }
     }
 
     public function testInvokesDelegateIfRequestDoesNotContainRouteResult()
@@ -85,6 +96,10 @@ class DispatchMiddlewareTest extends TestCase
      */
     public function testInvalidRoutedMiddlewareInRouteResultResultsInException($middleware)
     {
+        $this->errorHandler = set_error_handler(function ($errno, $errstr) {
+            return true;
+        }, E_USER_DEPRECATED);
+
         $this->handler->{HANDLER_METHOD}()->shouldNotBeCalled();
         $routeResult = RouteResult::fromRoute(new Route('/', $middleware));
         $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);


### PR DESCRIPTION
This patch marks two deprecations for version 3.0:

- `RouteResult::getMatchedMiddleware()` will be removed in version 3.0.
- The constructor for `Route` will only allow PSR-15 middleware starting in version 3.0.