### PR TITLE
HEAD / OPTIONS requests fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "malukenho/docheader": "^0.1.6",
         "phpunit/phpunit": "^6.5.5",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-diactoros": "^1.7"
+        "zendframework/zend-diactoros": "^1.7",
+        "zendframework/zend-stratigility": "^3.0.0rc1"
     },
     "suggest": {
         "zendframework/zend-expressive-aurarouter": "^3.0 to use the Aura.Router routing adapter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "54e40a620ad15eaac0d02fe8ee743743",
+    "content-hash": "63645d405db54c6aa12f9c8390a46766",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -2105,6 +2105,117 @@
                 "psr-7"
             ],
             "time": "2018-02-26T15:44:50+00:00"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-escaper",
+            "keywords": [
+                "escaper",
+                "zf2"
+            ],
+            "time": "2016-06-30T19:48:38+00:00"
+        },
+        {
+            "name": "zendframework/zend-stratigility",
+            "version": "3.0.0rc1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stratigility.git",
+                "reference": "6e76a8bd5b50d1cbd0b7f702a6f61293290b4382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/6e76a8bd5b50d1cbd0b7f702a6f61293290b4382",
+                "reference": "6e76a8bd5b50d1cbd0b7f702a6f61293290b4382",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0",
+                "psr/http-server-middleware": "^1.0",
+                "zendframework/zend-escaper": "^2.3"
+            },
+            "conflict": {
+                "zendframework/zend-diactoros": "<1.7.1"
+            },
+            "require-dev": {
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^7.0.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-diactoros": "^1.7.1"
+            },
+            "suggest": {
+                "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/double-pass-middleware.php",
+                    "src/functions/host.php",
+                    "src/functions/middleware.php",
+                    "src/functions/path.php"
+                ],
+                "psr-4": {
+                    "Zend\\Stratigility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR-7 middleware foundation for building and dispatching middleware pipelines",
+            "keywords": [
+                "ZendFramework",
+                "http",
+                "middleware",
+                "psr-15",
+                "psr-7",
+                "zf"
+            ],
+            "time": "2018-02-26T15:56:54+00:00"
         }
     ],
     "aliases": [],

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -89,10 +89,8 @@ class ImplicitHeadMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $allowedMethods = $result->getAllowedMethods();
-
         $route = $result->getMatchedRoute();
-        if (! $allowedMethods || ($route && ! $route->implicitHead())) {
+        if ($route && ! $route->implicitHead()) {
             return $handler->handle($request);
         }
 

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -89,8 +89,7 @@ class ImplicitHeadMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $route = $result->getMatchedRoute();
-        if ($route && ! $route->implicitHead()) {
+        if ($result->getMatchedRoute()) {
             return $handler->handle($request);
         }
 

--- a/src/Middleware/ImplicitHeadMiddlewareFactory.php
+++ b/src/Middleware/ImplicitHeadMiddlewareFactory.php
@@ -13,32 +13,24 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Router\Exception\MissingDependencyException;
+use Zend\Expressive\Router\RouterInterface;
 
 /**
  * Create and return an ImplicitHeadMiddleware instance.
  *
  * This factory depends on two other services:
  *
- * - Psr\Http\Message\ResponseInterface, which should resolve to a callable
- *   that will produce an empty Psr\Http\Message\ResponseInterface instance.
  * - Psr\Http\Message\StreamInterface, which should resolve to a callable
  *   that will produce an empty Psr\Http\Message\StreamInterface instance.
  */
 class ImplicitHeadMiddlewareFactory
 {
     /**
-     * @throws MissingDependencyException if either the Psr\Http\Message\ResponseInterface
-     *     or Psr\Http\Message\StreamInterface services are missing.
+     * @throws MissingDependencyException if the Psr\Http\Message\StreamInterface
+     *     service is missing.
      */
     public function __invoke(ContainerInterface $container) : ImplicitHeadMiddleware
     {
-        if (! $container->has(ResponseInterface::class)) {
-            throw MissingDependencyException::dependencyForService(
-                ResponseInterface::class,
-                ImplicitHeadMiddleware::class
-            );
-        }
-
         if (! $container->has(StreamInterface::class)) {
             throw MissingDependencyException::dependencyForService(
                 StreamInterface::class,
@@ -47,7 +39,7 @@ class ImplicitHeadMiddlewareFactory
         }
 
         return new ImplicitHeadMiddleware(
-            $container->get(ResponseInterface::class),
+            $container->get(RouterInterface::class),
             $container->get(StreamInterface::class)
         );
     }

--- a/src/Middleware/ImplicitHeadMiddlewareFactory.php
+++ b/src/Middleware/ImplicitHeadMiddlewareFactory.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Zend\Expressive\Router\Middleware;
 
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Router\Exception\MissingDependencyException;
 use Zend\Expressive\Router\RouterInterface;
@@ -20,17 +19,26 @@ use Zend\Expressive\Router\RouterInterface;
  *
  * This factory depends on two other services:
  *
+ * - Zend\Expressive\Router\RouterInterface, which should resolve to an
+ *   instance of that interface.
  * - Psr\Http\Message\StreamInterface, which should resolve to a callable
  *   that will produce an empty Psr\Http\Message\StreamInterface instance.
  */
 class ImplicitHeadMiddlewareFactory
 {
     /**
-     * @throws MissingDependencyException if the Psr\Http\Message\StreamInterface
-     *     service is missing.
+     * @throws MissingDependencyException if either the Zend\Expressive\Router\RouterInterface
+     *     or Psr\Http\Message\StreamInterface services are missing.
      */
     public function __invoke(ContainerInterface $container) : ImplicitHeadMiddleware
     {
+        if (! $container->has(RouterInterface::class)) {
+            throw MissingDependencyException::dependencyForService(
+                RouterInterface::class,
+                ImplicitHeadMiddleware::class
+            );
+        }
+
         if (! $container->has(StreamInterface::class)) {
             throw MissingDependencyException::dependencyForService(
                 StreamInterface::class,

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -68,17 +68,16 @@ class ImplicitOptionsMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        /** @var RouteResult $result */
-        if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
+        $result = $request->getAttribute(RouteResult::class);
+        if (! $result) {
+            return $handler->handle($request);
+        }
+
+        if ($result->getMatchedRoute()) {
             return $handler->handle($request);
         }
 
         $allowedMethods = $result->getAllowedMethods();
-
-        $route = $result->getMatchedRoute();
-        if (! $allowedMethods || ($route && ! $route->implicitOptions())) {
-            return $handler->handle($request);
-        }
 
         return ($this->responseFactory)()->withHeader('Allow', implode(',', $allowedMethods));
     }

--- a/src/Route.php
+++ b/src/Route.php
@@ -36,18 +36,6 @@ class Route implements MiddlewareInterface
     public const HTTP_METHOD_SEPARATOR = ':';
 
     /**
-     * @var bool If HEAD was not provided to the Route instance, indicate
-     *     support for the method is implicit.
-     */
-    private $implicitHead;
-
-    /**
-     * @var bool If OPTIONS was not provided to the Route instance, indicate
-     *     support for the method is implicit.
-     */
-    private $implicitOptions;
-
-    /**
      * @var null|string[] HTTP methods allowed with this route.
      */
     private $methods;
@@ -94,11 +82,6 @@ class Route implements MiddlewareInterface
                 : $path . '^' . implode(self::HTTP_METHOD_SEPARATOR, $this->methods);
         }
         $this->name = $name;
-
-        $this->implicitHead = is_array($this->methods)
-            && ! in_array(RequestMethod::METHOD_HEAD, $this->methods, true);
-        $this->implicitOptions = is_array($this->methods)
-            && ! in_array(RequestMethod::METHOD_OPTIONS, $this->methods, true);
     }
 
     /**
@@ -165,22 +148,6 @@ class Route implements MiddlewareInterface
     public function getOptions() : array
     {
         return $this->options;
-    }
-
-    /**
-     * Whether or not HEAD support is implicit (i.e., not explicitly specified)
-     */
-    public function implicitHead() : bool
-    {
-        return $this->implicitHead;
-    }
-
-    /**
-     * Whether or not OPTIONS support is implicit (i.e., not explicitly specified)
-     */
-    public function implicitOptions() : bool
-    {
-        return $this->implicitOptions;
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -148,9 +148,7 @@ class Route implements MiddlewareInterface
     public function allowsMethod(string $method) : bool
     {
         $method = strtoupper($method);
-        if (RequestMethod::METHOD_HEAD === $method
-            || RequestMethod::METHOD_OPTIONS === $method
-            || $this->methods === self::HTTP_METHOD_ANY
+        if ($this->methods === self::HTTP_METHOD_ANY
             || in_array($method, $this->methods, true)
         ) {
             return true;

--- a/src/Route.php
+++ b/src/Route.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Router;
 
-use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;

--- a/src/Test/ImplicitMethodsIntegrationTest.php
+++ b/src/Test/ImplicitMethodsIntegrationTest.php
@@ -12,6 +12,7 @@ namespace Zend\Expressive\Router\Test;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Generator;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
@@ -142,31 +143,16 @@ abstract class ImplicitMethodsIntegrationTest extends TestCase
         $finalHandler = $this->prophesize(RequestHandlerInterface::class);
         $finalHandler
             ->handle(Argument::that(function (ServerRequestInterface $request) use ($method, $implicitRoute) {
-                if ($request->getMethod() !== $method) {
-                    return false;
-                }
-
-                if ($request->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE) !== null) {
-                    return false;
-                }
+                Assert::assertSame($method, $request->getMethod());
+                Assert::assertNull($request->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE));
 
                 $routeResult = $request->getAttribute(RouteResult::class);
-                if (! $routeResult) {
-                    return false;
-                }
-
-                if (! $routeResult->isSuccess()) {
-                    return false;
-                }
+                Assert::assertInstanceOf(RouteResult::class, $routeResult);
+                Assert::assertTrue($routeResult->isSuccess());
 
                 $matchedRoute = $routeResult->getMatchedRoute();
-                if (! $matchedRoute) {
-                    return false;
-                }
-
-                if ($matchedRoute !== $implicitRoute) {
-                    return false;
-                }
+                Assert::assertNotNull($matchedRoute);
+                Assert::assertSame($implicitRoute, $matchedRoute);
 
                 return true;
             }))
@@ -252,33 +238,19 @@ abstract class ImplicitMethodsIntegrationTest extends TestCase
         $finalHandler = $this->prophesize(RequestHandlerInterface::class);
         $finalHandler
             ->handle(Argument::that(function (ServerRequestInterface $request) use ($route1) {
-                if ($request->getMethod() !== RequestMethod::METHOD_GET) {
-                    return false;
-                }
-
-                if ($request->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE)
-                    !== RequestMethod::METHOD_HEAD
-                ) {
-                    return false;
-                }
+                Assert::assertSame(RequestMethod::METHOD_GET, $request->getMethod());
+                Assert::assertSame(
+                    RequestMethod::METHOD_HEAD,
+                    $request->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE)
+                );
 
                 $routeResult = $request->getAttribute(RouteResult::class);
-                if (! $routeResult) {
-                    return false;
-                }
-
-                if (! $routeResult->isSuccess()) {
-                    return false;
-                }
+                Assert::assertInstanceOf(RouteResult::class, $routeResult);
+                Assert::assertTrue($routeResult->isSuccess());
 
                 $matchedRoute = $routeResult->getMatchedRoute();
-                if (! $matchedRoute) {
-                    return false;
-                }
-
-                if ($matchedRoute !== $route1) {
-                    return false;
-                }
+                Assert::assertNotNull($matchedRoute);
+                Assert::assertSame($route1, $matchedRoute);
 
                 return true;
             }))

--- a/src/Test/ImplicitMethodsIntegrationTest.php
+++ b/src/Test/ImplicitMethodsIntegrationTest.php
@@ -177,14 +177,16 @@ abstract class ImplicitMethodsIntegrationTest extends TestCase
 
     public function withoutImplicitMiddleware()
     {
+        // @codingStandardsIgnoreStart
         // request method, array of allowed methods for a route.
-        yield 'HEAD: get' => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_GET]];
-        yield 'HEAD: post' => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_POST]];
-        yield 'HEAD: get, post' => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]];
+        yield 'HEAD: get'          => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_GET]];
+        yield 'HEAD: post'         => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_POST]];
+        yield 'HEAD: get, post'    => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]];
 
-        yield 'OPTIONS: get' => [RequestMethod::METHOD_OPTIONS, [RequestMethod::METHOD_GET]];
-        yield 'OPTIONS: post' => [RequestMethod::METHOD_OPTIONS, [RequestMethod::METHOD_POST]];
+        yield 'OPTIONS: get'       => [RequestMethod::METHOD_OPTIONS, [RequestMethod::METHOD_GET]];
+        yield 'OPTIONS: post'      => [RequestMethod::METHOD_OPTIONS, [RequestMethod::METHOD_POST]];
         yield 'OPTIONS: get, post' => [RequestMethod::METHOD_OPTIONS, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]];
+        // @codingStandardsIgnoreEnd
     }
 
     /**
@@ -254,7 +256,8 @@ abstract class ImplicitMethodsIntegrationTest extends TestCase
 
                     return true;
                 }),
-                Argument::type(RequestHandlerInterface::class))
+                Argument::type(RequestHandlerInterface::class)
+            )
             ->willReturn($finalResponse);
 
         $route2 = new Route('/api/v1/me', $middleware2->reveal(), [RequestMethod::METHOD_POST]);

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -33,8 +33,17 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
         $this->factory = new ImplicitHeadMiddlewareFactory();
     }
 
+    public function testFactoryRaisesExceptionIfRouterInterfaceServiceIsMissing()
+    {
+        $this->container->has(RouterInterface::class)->willReturn(false);
+
+        $this->expectException(MissingDependencyException::class);
+        ($this->factory)($this->container->reveal());
+    }
+
     public function testFactoryRaisesExceptionIfStreamFactoryServiceIsMissing()
     {
+        $this->container->has(RouterInterface::class)->willReturn(true);
         $this->container->has(StreamInterface::class)->willReturn(false);
 
         $this->expectException(MissingDependencyException::class);
@@ -47,9 +56,10 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
         $streamFactory = function () {
         };
 
+        $this->container->has(RouterInterface::class)->willReturn(true);
         $this->container->has(StreamInterface::class)->willReturn(true);
-        $this->container->get(StreamInterface::class)->willReturn($streamFactory);
         $this->container->get(RouterInterface::class)->will([$router, 'reveal']);
+        $this->container->get(StreamInterface::class)->willReturn($streamFactory);
 
         $middleware = ($this->factory)($this->container->reveal());
 

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Expressive\Router\Middleware;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Router\Exception\MissingDependencyException;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Router\Exception\MissingDependencyException;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddlewareFactory;
+use Zend\Expressive\Router\RouterInterface;
 
 class ImplicitHeadMiddlewareFactoryTest extends TestCase
 {
@@ -32,18 +33,8 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
         $this->factory = new ImplicitHeadMiddlewareFactory();
     }
 
-    public function testFactoryRaisesExceptionIfResponseFactoryServiceIsMissing()
-    {
-        $this->container->has(ResponseInterface::class)->willReturn(false);
-        $this->container->has(StreamInterface::class)->shouldNotBeCalled();
-
-        $this->expectException(MissingDependencyException::class);
-        ($this->factory)($this->container->reveal());
-    }
-
     public function testFactoryRaisesExceptionIfStreamFactoryServiceIsMissing()
     {
-        $this->container->has(ResponseInterface::class)->willReturn(true);
         $this->container->has(StreamInterface::class)->willReturn(false);
 
         $this->expectException(MissingDependencyException::class);
@@ -52,16 +43,13 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
 
     public function testFactoryProducesImplicitHeadMiddlewareWhenAllDependenciesPresent()
     {
-        $responseFactory = function () {
-        };
+        $router = $this->prophesize(RouterInterface::class);
         $streamFactory = function () {
         };
 
-        $this->container->has(ResponseInterface::class)->willReturn(true);
         $this->container->has(StreamInterface::class)->willReturn(true);
-
-        $this->container->get(ResponseInterface::class)->willReturn($responseFactory);
         $this->container->get(StreamInterface::class)->willReturn($streamFactory);
+        $this->container->get(RouterInterface::class)->will([$router, 'reveal']);
 
         $middleware = ($this->factory)($this->container->reveal());
 

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -21,30 +20,29 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 class ImplicitHeadMiddlewareTest extends TestCase
 {
     /** @var ImplicitHeadMiddleware */
     private $middleware;
 
-    /** @var ResponseInterface|ObjectProphecy */
-    private $response;
+    /** @var RouterInterface|ObjectProphecy */
+    private $router;
 
     /** @var StreamInterface|ObjectProphecy */
     private $stream;
 
     public function setUp()
     {
-        $this->response = $this->prophesize(ResponseInterface::class);
+        $this->router = $this->prophesize(RouterInterface::class);
         $this->stream = $this->prophesize(StreamInterface::class);
-        $responseFactory = function () {
-            return $this->response->reveal();
-        };
+
         $streamFactory = function () {
             return $this->stream->reveal();
         };
 
-        $this->middleware = new ImplicitHeadMiddleware($responseFactory, $streamFactory);
+        $this->middleware = new ImplicitHeadMiddleware($this->router->reveal(), $streamFactory);
     }
 
     public function testReturnsResultOfHandlerOnNonHeadRequests()
@@ -137,13 +135,22 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
         $request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+        $request->withMethod(RequestMethod::METHOD_GET)->will([$request, 'reveal']);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(true);
+
+        $this->router->match($request)->will([$result, 'reveal']);
+        $request->withAttribute(RouteResult::class, $result)->will([$request, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class);
 
         $handler = $this->prophesize(RequestHandlerInterface::class);
-        $handler->handle($request->reveal())->shouldNotBeCalled();
+        $handler->handle($request->reveal())->will([$response, 'reveal']);
 
         $result = $this->middleware->process($request->reveal(), $handler->reveal());
 
-        $this->assertSame($this->response->reveal(), $result);
+        $this->assertSame($response->reveal(), $result);
     }
 
     public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet()
@@ -169,7 +176,13 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class);
         $response->withBody($this->stream->reveal())->will([$response, 'reveal']);
 
-        $this->response->withBody($this->stream->reveal())->shouldNotBeCalled();
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(false);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request->withAttribute(RouteResult::class, $result->reveal())->will([$request, 'reveal']);
+
+        $this->router->match($request)->will([$result, 'reveal']);
 
         $handler = $this->prophesize(RequestHandlerInterface::class);
         $handler

--- a/test/Middleware/MethodNotAllowedMiddlewareTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Router\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;

--- a/test/Middleware/PathBasedRoutingMiddlewareTest.php
+++ b/test/Middleware/PathBasedRoutingMiddlewareTest.php
@@ -20,7 +20,6 @@ use TypeError;
 use Zend\Expressive\Router\Exception;
 use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\Expressive\Router\Route;
-use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
 
 class PathBasedRoutingMiddlewareTest extends TestCase

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router\Middleware;
 
-use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -69,16 +69,16 @@ class RouteTest extends TestCase
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_DELETE));
     }
 
-    public function testRouteAlwaysAllowsHeadMethod()
+    public function testRouteHeadMethodIsNotAllowedByDefault()
     {
         $route = new Route('/foo', $this->noopMiddleware, []);
-        $this->assertTrue($route->allowsMethod(RequestMethod::METHOD_HEAD));
+        $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_HEAD));
     }
 
-    public function testRouteAlwaysAllowsOptionsMethod()
+    public function testRouteOptionsMethodIsNotAllowedByDefault()
     {
         $route = new Route('/foo', $this->noopMiddleware, []);
-        $this->assertTrue($route->allowsMethod(RequestMethod::METHOD_OPTIONS));
+        $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_OPTIONS));
     }
 
     public function testRouteAllowsSpecifyingOptions()

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -177,40 +177,6 @@ class RouteTest extends TestCase
         new Route('/test', $this->noopMiddleware, $invalidHttpMethods);
     }
 
-    public function testProvidingArrayOfMethodsWithoutHeadOrOptionsImpliesBoth()
-    {
-        $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]);
-        $this->assertTrue($route->implicitHead());
-        $this->assertTrue($route->implicitOptions());
-    }
-
-    public function headAndOptions()
-    {
-        return [
-            'head'    => [RequestMethod::METHOD_HEAD, 'implicitHead'],
-            'options' => [RequestMethod::METHOD_OPTIONS, 'implicitOptions'],
-        ];
-    }
-
-    /**
-     * @dataProvider headAndOptions
-     *
-     * @param string $httpMethod
-     * @param string $implicitMethod
-     */
-    public function testPassingHeadOrOptionsInMethodArrayDoesNotMarkAsImplicit($httpMethod, $implicitMethod)
-    {
-        $route = new Route('/test', $this->noopMiddleware, [$httpMethod]);
-        $this->assertFalse($route->{$implicitMethod}());
-    }
-
-    public function testPassingWildcardMethodDoesNotMarkAsImplicit()
-    {
-        $route = new Route('/test', $this->noopMiddleware, Route::HTTP_METHOD_ANY);
-        $this->assertFalse($route->implicitHead());
-        $this->assertFalse($route->implicitOptions());
-    }
-
     public function testAllowsHttpInteropMiddleware()
     {
         $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();


### PR DESCRIPTION
In backporting changes to the v2 releases, we discovered that the integration tests were not properly testing expected and/or typical workflows with regards to the `Implicit*Middleware` and `MethodNotFoundMiddleware`. This patch updates the tests to be more thorough and test common scenarios.