### PR TITLE
Raise exception in Route constructor when no HTTP methods provided

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -160,6 +160,12 @@ class Route implements MiddlewareInterface
      */
     private function validateHttpMethods(array $methods) : array
     {
+        if (empty($methods)) {
+            throw new Exception\InvalidArgumentException(
+                'HTTP methods argument was empty; must contain at least one method'
+            );
+        }
+
         if (false === array_reduce($methods, function ($valid, $method) {
             if (false === $valid) {
                 return false;

--- a/test/Middleware/PathBasedRoutingMiddlewareTest.php
+++ b/test/Middleware/PathBasedRoutingMiddlewareTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router\Middleware;
 
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -72,11 +73,11 @@ class PathBasedRoutingMiddlewareTest extends TestCase
     public function commonHttpMethods()
     {
         return [
-            'GET'    => ['GET'],
-            'POST'   => ['POST'],
-            'PUT'    => ['PUT'],
-            'PATCH'  => ['PATCH'],
-            'DELETE' => ['DELETE'],
+            RequestMethod::METHOD_GET    => [RequestMethod::METHOD_GET],
+            RequestMethod::METHOD_POST   => [RequestMethod::METHOD_POST],
+            RequestMethod::METHOD_PUT    => [RequestMethod::METHOD_PUT],
+            RequestMethod::METHOD_PATCH  => [RequestMethod::METHOD_PATCH],
+            RequestMethod::METHOD_DELETE => [RequestMethod::METHOD_DELETE],
         ];
     }
 
@@ -178,7 +179,7 @@ class PathBasedRoutingMiddlewareTest extends TestCase
     public function testCreatingHttpRouteMethodWithExistingPathButDifferentMethodCreatesNewRouteInstance()
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
-        $route = $this->middleware->route('/foo', $this->noopMiddleware, ['POST']);
+        $route = $this->middleware->route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_POST]);
 
         $middleware = $this->createNoopMiddleware();
         $test = $this->middleware->get('/foo', $middleware);

--- a/test/Middleware/PathBasedRoutingMiddlewareTest.php
+++ b/test/Middleware/PathBasedRoutingMiddlewareTest.php
@@ -178,7 +178,7 @@ class PathBasedRoutingMiddlewareTest extends TestCase
     public function testCreatingHttpRouteMethodWithExistingPathButDifferentMethodCreatesNewRouteInstance()
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
-        $route = $this->middleware->route('/foo', $this->noopMiddleware, []);
+        $route = $this->middleware->route('/foo', $this->noopMiddleware, ['POST']);
 
         $middleware = $this->createNoopMiddleware();
         $test = $this->middleware->get('/foo', $middleware);

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -71,13 +71,13 @@ class RouteTest extends TestCase
 
     public function testRouteHeadMethodIsNotAllowedByDefault()
     {
-        $route = new Route('/foo', $this->noopMiddleware, ['GET']);
+        $route = new Route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_GET]);
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_HEAD));
     }
 
     public function testRouteOptionsMethodIsNotAllowedByDefault()
     {
-        $route = new Route('/foo', $this->noopMiddleware, ['GET']);
+        $route = new Route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_GET]);
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_OPTIONS));
     }
 
@@ -103,7 +103,7 @@ class RouteTest extends TestCase
 
     public function testRouteNameWithConstructor()
     {
-        $route = new Route('/test', $this->noopMiddleware, ['GET'], 'test');
+        $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET], 'test');
         $this->assertSame('test', $route->getName());
     }
 
@@ -116,7 +116,7 @@ class RouteTest extends TestCase
     public function testRouteNameWithGetAndPost()
     {
         $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]);
-        $this->assertSame('/test^GET' . Route::HTTP_METHOD_SEPARATOR . 'POST', $route->getName());
+        $this->assertSame('/test^GET' . Route::HTTP_METHOD_SEPARATOR . RequestMethod::METHOD_POST, $route->getName());
     }
 
     public function testThrowsExceptionDuringConstructionIfPathIsNotString()

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -71,13 +71,13 @@ class RouteTest extends TestCase
 
     public function testRouteHeadMethodIsNotAllowedByDefault()
     {
-        $route = new Route('/foo', $this->noopMiddleware, []);
+        $route = new Route('/foo', $this->noopMiddleware, ['GET']);
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_HEAD));
     }
 
     public function testRouteOptionsMethodIsNotAllowedByDefault()
     {
-        $route = new Route('/foo', $this->noopMiddleware, []);
+        $route = new Route('/foo', $this->noopMiddleware, ['GET']);
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_OPTIONS));
     }
 
@@ -103,7 +103,7 @@ class RouteTest extends TestCase
 
     public function testRouteNameWithConstructor()
     {
-        $route = new Route('/test', $this->noopMiddleware, [], 'test');
+        $route = new Route('/test', $this->noopMiddleware, ['GET'], 'test');
         $this->assertSame('test', $route->getName());
     }
 
@@ -229,5 +229,14 @@ class RouteTest extends TestCase
 
         $route = new Route('/foo', $middleware->reveal());
         $this->assertSame($response, $route->process($request, $handler));
+    }
+
+    public function testConstructorShouldRaiseExceptionIfMethodsArgumentIsAnEmptyArray()
+    {
+        $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('empty');
+        new Route('/foo', $middleware, []);
     }
 }


### PR DESCRIPTION
Routes _require_ one or more HTTP methods in order to be valid.