### PR TITLE
Better deprecation messages for non-middleware interface routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ before_install:
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
-  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer remove $COMPOSER_ARGS --dev --no-update http-interop/http-middleware; travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer remove $COMPOSER_ARGS --dev --no-update http-interop/http-middleware; travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.4.1 - 2018-03-08
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#63](https://github.com/zendframework/zend-expressive-router/pull/63)
+  improves the deprecation notice raised by the `Zend\Expressive\Router\Route`
+  constructor when non-middleware interface implementations are passed for the
+  `$middleware` argument. The message not contains the path, HTTP methods, and
+  middleware type that were used to create the `Route` instance.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.4.0 - 2018-03-08
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "webimpress/http-middleware-compatibility": "^0.1.1"
     },
     "require-dev": {
+        "http-interop/http-middleware": "0.4.1",
         "malukenho/docheader": "^0.1.5",
         "phpunit/phpunit": "^5.7.23 || ^6.4.3",
         "zendframework/zend-coding-standard": "~1.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf05243eb602d9b93653fd198b1dd77c",
+    "content-hash": "f79ea5482f7d80c8769b4c7239759ab2",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -58,16 +58,16 @@
         },
         {
             "name": "http-interop/http-middleware",
-            "version": "0.5.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +82,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\Server\\": "src/"
+                    "Interop\\Http\\ServerMiddleware\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,16 +97,17 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
+                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-15",
+                "psr-17",
                 "psr-7",
                 "request",
                 "response"
             ],
             "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-09-18T15:27:03+00:00"
+            "time": "2017-01-14T15:23:42+00:00"
         },
         {
             "name": "psr/container",

--- a/src/Route.php
+++ b/src/Route.php
@@ -272,7 +272,7 @@ class Route
             $type = 'callable:' . $middleware;
         } elseif (is_string($middleware) && ! is_callable($middleware)) {
             $type = 'string:' . $middleware;
-        } elseif (is_callable($middleware) && is_object($middleware)) {
+        } elseif (is_object($middleware)) {
             $type = get_class($middleware);
         } elseif (is_callable($middleware)) {
             $type = 'callable';

--- a/src/Route.php
+++ b/src/Route.php
@@ -287,8 +287,8 @@ class Route
         trigger_error(sprintf(
             '%1$s will not accept anything other than objects implementing the MiddlewareInterface'
             . ' starting in version 3.0.0; we detected usage of "%2$s" for path "%3$s" using methods %4$s.'
-            . ' Please update your code to create %1$s instances'
-            . ' using MiddlewareInterface instances.',
+            . ' Please update your code to create middleware instances implementing MiddlewareInterface;'
+            . ' use decorators for callable middleware if needed.',
             __CLASS__,
             $type,
             $path,

--- a/src/Route.php
+++ b/src/Route.php
@@ -83,12 +83,7 @@ class Route
         }
 
         if (! $middleware instanceof MiddlewareInterface) {
-            trigger_error(sprintf(
-                '%1$s will not accept anything other than objects implementing the MiddlewareInterface'
-                . ' starting in version 3.0.0. Please update your code to create %1$s instances'
-                . ' using MiddlewareInterface instances.',
-                __CLASS__
-            ), E_USER_DEPRECATED);
+            $this->triggerDeprecationForNonMiddlewareImplementation($path, $middleware, $methods);
         }
 
         if (! is_callable($middleware)
@@ -261,5 +256,43 @@ class Route
         }
 
         return array_map('strtoupper', $methods);
+    }
+
+    /**
+     * @param string $path
+     * @param mixed $middleware
+     * @param null|array $methods
+     */
+    private function triggerDeprecationForNonMiddlewareImplementation($path, $middleware, $methods)
+    {
+        $type = $middleware;
+        if (is_string($middleware) && class_exists($middleware)) {
+            $type = $middleware;
+        } elseif (is_string($middleware) && is_callable($middleware)) {
+            $type = 'callable:' . $middleware;
+        } elseif (is_string($middleware) && ! is_callable($middleware)) {
+            $type = 'string:' . $middleware;
+        } elseif (is_callable($middleware) && is_object($middleware)) {
+            $type = get_class($middleware);
+        } elseif (is_callable($middleware)) {
+            $type = 'callable';
+        } else {
+            $type = gettype($middleware);
+        }
+
+        $methods = is_array($methods)
+            ? implode(', ', $methods)
+            : '(any)';
+
+        trigger_error(sprintf(
+            '%1$s will not accept anything other than objects implementing the MiddlewareInterface'
+            . ' starting in version 3.0.0; we detected usage of "%2$s" for path "%3$s" using methods %4$s.'
+            . ' Please update your code to create %1$s instances'
+            . ' using MiddlewareInterface instances.',
+            __CLASS__,
+            $type,
+            $path,
+            $methods
+        ), E_USER_DEPRECATED);
     }
 }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -284,26 +284,31 @@ class RouteTest extends TestCase
 
     public function validNonInteropMiddleware()
     {
-        yield 'string-callable' => ['sprintf'];
-        yield 'array' => [['sprintf']];
-        yield 'array-callable' => [[$this, 'setUp']];
+        yield 'string-callable' => ['sprintf', '"callable:sprintf"'];
+        yield 'array' => [['sprintf'], '"array"'];
+        yield 'array-callable' => [[$this, 'setUp'], '"callable"'];
     }
 
     /**
      * @dataProvider validNonInteropMiddleware
      * @param mixed $middleware
+     * @param string $expectedMessage
      */
-    public function testPassingNonInteropMiddlewareToConstructorTriggersDeprecationNotice($middleware)
-    {
-        $spy = (object) ['found' => false];
+    public function testPassingNonInteropMiddlewareToConstructorTriggersDeprecationNotice(
+        $middleware,
+        $expectedMessage
+    ) {
+        $spy = (object) ['found' => false, 'message' => ''];
         $this->errorHandler = set_error_handler(function ($errno, $errstr) use ($spy) {
             $spy->found = true;
+            $spy->message = $errstr;
             return true;
         }, E_USER_DEPRECATED);
 
         new Route('/test', $middleware);
 
         $this->assertTrue($spy->found);
+        $this->assertContains($expectedMessage, $spy->message);
     }
 
     public function testNoDeprecationNoticeRaisedForValidHttpInteropMiddlewareArguments()


### PR DESCRIPTION
This patch does two things:

- It adds tests to verify that the deprecation notices are not triggered for any variation of http-middleware middleware interfaces.
- It improves the deprecation message to ensure it contains useful details, such as the path, HTTP methods, and type used to create the route.