### PR TITLE
Renames `Middleware\PathBasedRoutingMiddleware` to `RouteCollector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ All notable changes to this project will be documented in this file, in reverse 
   need to configure within your application in order to work properly. See each
   factory for details.
 
-- [#47](https://github.com/zendframework/zend-expressive-router/pull/47) and
-  [#50](https://github.com/zendframework/zend-expressive-router/pull/50) add
-  the middleware `Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware`,
-  which extends the `RouteMiddleware` to add methods for defining and creating
-  path+method based routes. It exposes the following methods:
+- [#47](https://github.com/zendframework/zend-expressive-router/pull/47),
+  [#50](https://github.com/zendframework/zend-expressive-router/pull/50), and
+  [#64](https://github.com/zendframework/zend-expressive-router/pull/64) add
+  the `Zend\Expressive\Router\RouteCollector` class,
+  which composes a `RouterInterface`, and provides methods for defining and
+  creating path+method based routes. It exposes the following methods:
 
   - `route(string $path, MiddlewareInterface $middleware, array $methods = null, string $name = null) : Route`
   - `get(string $path, MiddlewareInterface $middleware, string $name = null) : Route`

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -27,8 +27,8 @@ class ConfigProvider
                 Middleware\ImplicitHeadMiddleware::class     => Middleware\ImplicitHeadMiddlewareFactory::class,
                 Middleware\ImplicitOptionsMiddleware::class  => Middleware\ImplicitOptionsMiddlewareFactory::class,
                 Middleware\MethodNotAllowedMiddleware::class => Middleware\MethodNotAllowedMiddlewareFactory::class,
-                Middleware\PathBasedRoutingMiddleware::class => Middleware\PathBasedRoutingMiddlewareFactory::class,
                 Middleware\RouteMiddleware::class            => Middleware\RouteMiddlewareFactory::class,
+                RouteCollector::class                        => RouteCollectorFactory::class,
             ]
         ];
         // @codingStandardsIgnoreEnd

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -7,17 +7,15 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router\Middleware;
+namespace Zend\Expressive\Router;
 
 use Psr\Http\Server\MiddlewareInterface;
-use Zend\Expressive\Router\Exception;
-use Zend\Expressive\Router\Route;
 
 /**
- * Routing middleware for path-based routes.
+ * Aggregate routes for the router.
  *
- * This middleware extends the RouteMiddleware in order to provide additional
- * methods for creating path+HTTP method-based routes:
+ * This class provides * methods for creating path+HTTP method-based routes and
+ * injecting them into the router:
  *
  * - get
  * - post
@@ -29,18 +27,28 @@ use Zend\Expressive\Router\Route;
  * A general `route()` method allows specifying multiple request methods and/or
  * arbitrary request methods when creating a path-based route.
  *
- * Internally, the middleware performs some checks for duplicate routes when
+ * Internally, the class performs some checks for duplicate routes when
  * attaching via one of the exposed methods, and will raise an exception when a
  * collision occurs.
  */
-class PathBasedRoutingMiddleware extends RouteMiddleware
+class RouteCollector
 {
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
     /**
      * List of all routes registered directly with the application.
      *
      * @var Route[]
      */
     private $routes = [];
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
 
     /**
      * Add a route for the route middleware to match.

--- a/src/RouteCollectorFactory.php
+++ b/src/RouteCollectorFactory.php
@@ -7,35 +7,33 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Router\Middleware;
+namespace Zend\Expressive\Router;
 
 use Psr\Container\ContainerInterface;
-use Zend\Expressive\Router\Exception\MissingDependencyException;
-use Zend\Expressive\Router\RouterInterface;
 
 /**
- * Create and return a PathBasedRoutingMiddleware instance.
+ * Create and return a RouteCollector instance.
  *
  * This factory depends on one other service:
  *
  * - Zend\Expressive\Router\RouterInterface, which should resolve to
  *   a class implementing that interface.
  */
-class PathBasedRoutingMiddlewareFactory
+class RouteCollectorFactory
 {
     /**
      * @throws MissingDependencyException if the RouterInterface service is
      *     missing.
      */
-    public function __invoke(ContainerInterface $container) : PathBasedRoutingMiddleware
+    public function __invoke(ContainerInterface $container) : RouteCollector
     {
         if (! $container->has(RouterInterface::class)) {
-            throw MissingDependencyException::dependencyForService(
+            throw Exception\MissingDependencyException::dependencyForService(
                 RouterInterface::class,
                 PathBasedRoutingMiddleware::class
             );
         }
 
-        return new PathBasedRoutingMiddleware($container->get(RouterInterface::class));
+        return new RouteCollector($container->get(RouterInterface::class));
     }
 }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Expressive\Router;
 use PHPUnit\Framework\TestCase;
 use Zend\Expressive\Router\ConfigProvider;
 use Zend\Expressive\Router\Middleware;
+use Zend\Expressive\Router\RouteCollector;
 
 class ConfigProviderTest extends TestCase
 {
@@ -26,7 +27,7 @@ class ConfigProviderTest extends TestCase
         $this->assertArrayHasKey(Middleware\ImplicitHeadMiddleware::class, $factories);
         $this->assertArrayHasKey(Middleware\ImplicitOptionsMiddleware::class, $factories);
         $this->assertArrayHasKey(Middleware\MethodNotAllowedMiddleware::class, $factories);
-        $this->assertArrayHasKey(Middleware\PathBasedRoutingMiddleware::class, $factories);
         $this->assertArrayHasKey(Middleware\RouteMiddleware::class, $factories);
+        $this->assertArrayHasKey(RouteCollector::class, $factories);
     }
 }

--- a/test/RouteCollectorFactoryTest.php
+++ b/test/RouteCollectorFactoryTest.php
@@ -7,28 +7,28 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Router\Middleware;
+namespace ZendTest\Expressive\Router;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Router\Exception\MissingDependencyException;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddlewareFactory;
+use Zend\Expressive\Router\RouteCollector;
+use Zend\Expressive\Router\RouteCollectorFactory;
 use Zend\Expressive\Router\RouterInterface;
 
-class PathBasedRoutingMiddlewareFactoryTest extends TestCase
+class RouteCollectorFactoryTest extends TestCase
 {
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
-    /** @var PathBasedRoutingMiddlewareFactory */
+    /** @var RouteCollectorFactory */
     private $factory;
 
     public function setUp()
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->factory = new PathBasedRoutingMiddlewareFactory();
+        $this->factory = new RouteCollectorFactory();
     }
 
     public function testFactoryRaisesExceptionIfRouterServiceIsMissing()
@@ -39,7 +39,7 @@ class PathBasedRoutingMiddlewareFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryProducesPathBasedRoutingMiddlewareWhenAllDependenciesPresent()
+    public function testFactoryProducesRouteCollectorWhenAllDependenciesPresent()
     {
         $router = $this->prophesize(RouterInterface::class)->reveal();
         $this->container->has(RouterInterface::class)->willReturn(true);
@@ -47,6 +47,6 @@ class PathBasedRoutingMiddlewareFactoryTest extends TestCase
 
         $middleware = ($this->factory)($this->container->reveal());
 
-        $this->assertInstanceOf(PathBasedRoutingMiddleware::class, $middleware);
+        $this->assertInstanceOf(RouteCollector::class, $middleware);
     }
 }


### PR DESCRIPTION
In documenting Expressive 3, I realized a few things:

- Having two routing middleware is confusing.
- There is no reason for the `Application` collaborator to be middleware; it just needs a mechanism for _creating_ and _collecting_ routes to inject in the router.

As such, this patch renames the `PathBasedRoutingMiddleware` to `RouteCollector`, and it no longer extends `RouteMiddleware`.

While this is a breaking change, it will lead to less confusion with the v3 release.