### PR TITLE
Hotfix #68 - Fixed exception message on missing dependency for RouteCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#69](https://github.com/zendframework/zend-expressive-router/pull/69) fixes
+  exception message on missing dependencies on creating `RouteCollector` to refer
+  that class.
 
 ## 3.0.0 - 2018-03-15
 

--- a/src/RouteCollectorFactory.php
+++ b/src/RouteCollectorFactory.php
@@ -30,7 +30,7 @@ class RouteCollectorFactory
         if (! $container->has(RouterInterface::class)) {
             throw Exception\MissingDependencyException::dependencyForService(
                 RouterInterface::class,
-                PathBasedRoutingMiddleware::class
+                RouteCollector::class
             );
         }
 

--- a/test/RouteCollectorFactoryTest.php
+++ b/test/RouteCollectorFactoryTest.php
@@ -36,6 +36,7 @@ class RouteCollectorFactoryTest extends TestCase
         $this->container->has(RouterInterface::class)->willReturn(false);
 
         $this->expectException(MissingDependencyException::class);
+        $this->expectExceptionMessage(RouteCollector::class);
         ($this->factory)($this->container->reveal());
     }
 


### PR DESCRIPTION
Fixes #68 
Use `RouteCollector` instead of non-existsing `PathBasedRoutingMiddleware` in factory in case of missing dependencies.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
