### PR TITLE
Fixed PHPDocs - correct reference to exception class

### DIFF
--- a/src/RouteCollectorFactory.php
+++ b/src/RouteCollectorFactory.php
@@ -22,7 +22,7 @@ use Psr\Container\ContainerInterface;
 class RouteCollectorFactory
 {
     /**
-     * @throws MissingDependencyException if the RouterInterface service is
+     * @throws Exception\MissingDependencyException if the RouterInterface service is
      *     missing.
      */
     public function __invoke(ContainerInterface $container) : RouteCollector


### PR DESCRIPTION
- [x] Is this related to quality assurance?

There was wrong reference to exception class in PHPDocs.