### PR TITLE
Fix OPTIONS request for not found routes

### DIFF
--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -75,6 +75,10 @@ class ImplicitOptionsMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
+        if ($result->isFailure() && ! $result->isMethodFailure()) {
+            return $handler->handle($request);
+        }
+
         if ($result->getMatchedRoute()) {
             return $handler->handle($request);
         }


### PR DESCRIPTION
Pass to next handler when route is not matched.

Fixes #72 

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
