### PR TITLE
Copy matched parameters for HEAD requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#74](https://github.com/zendframework/zend-expressive-router/pull/74) fixes
+  an issue with the `ImplicitHeadMiddleware` where matched route parameters
+  were not copied into the request and would cause exceptions that would
+  normally not happen for GET requests.
 
 ## 3.0.2 - 2018-03-21
 
@@ -140,7 +143,7 @@ All notable changes to this project will be documented in this file, in reverse 
   Implementors of `RouterInterface` should extend this class in their own test
   suite to ensure that they create appropriate `RouteResult` instances for each
   of the following cases:
-  
+
   - `HEAD` request called and matches one or more known routes, but the method
     is not defined for any of them.
   - `OPTIONS` request called and matches one or more known routes, but the method

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -98,6 +98,11 @@ class ImplicitHeadMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
+        // Copy matched parameters like RouteMiddleware does
+        foreach ($routeResult->getMatchedParams() as $param => $value) {
+            $request = $request->withAttribute($param, $value);
+        }
+
         $response = $handler->handle(
             $request
                 ->withAttribute(RouteResult::class, $routeResult)


### PR DESCRIPTION
Someone is spamming my site with HEAD requests and they are causing exceptions. I don't care much about the spamming, I'm more interested in why the request fails. It turns out for a normal GET request, the matched route parameters are copied into the request as attributes in the RouteMiddleware. The ImplicitHeadMiddleware runs after the RouteMiddleware and it tries to match the request again as a HEAD request, however it doesn't copy the matched route parameters into the request. This causes the handler to load it as a GET request, but it doesn't get the parameters and thus throws exceptions. I could check for an existing id but without a valid id, the GET route wouldn't be matched anyway and so shouldn't the HEAD request. 

There are 2 solutions I can think of. 

1. Always use the RouteResult to get matched parameters. But doing that, it means that modules can't be reused outside Expressive as other frameworks don't have a RouteResult.
2. Copy the parameters like RouteMiddleware does so the handler doesn't need to check if it is a GET or HEAD request and `$request->getAttribute('id')` can be used.

Unless someone has a better idea, I'll go for solution 2.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.