### PR TITLE
No mocking of RouteResult - tests improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#74](https://github.com/zendframework/zend-expressive-router/pull/74) fixes
+  an issue with the `ImplicitHeadMiddleware` where matched route parameters
+  were not copied into the request and would cause exceptions that would
+  normally not happen for GET requests.
 
 ## 3.0.2 - 2018-03-21
 
@@ -140,7 +143,7 @@ All notable changes to this project will be documented in this file, in reverse 
   Implementors of `RouterInterface` should extend this class in their own test
   suite to ensure that they create appropriate `RouteResult` instances for each
   of the following cases:
-  
+
   - `HEAD` request called and matches one or more known routes, but the method
     is not defined for any of them.
   - `OPTIONS` request called and matches one or more known routes, but the method

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -98,6 +98,11 @@ class ImplicitHeadMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
+        // Copy matched parameters like RouteMiddleware does
+        foreach ($routeResult->getMatchedParams() as $param => $value) {
+            $request = $request->withAttribute($param, $value);
+        }
+
         $response = $handler->handle(
             $request
                 ->withAttribute(RouteResult::class, $routeResult)

--- a/test/Middleware/MethodNotAllowedMiddlewareTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareTest.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
+use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 
 class MethodNotAllowedMiddlewareTest extends TestCase
@@ -61,10 +62,9 @@ class MethodNotAllowedMiddlewareTest extends TestCase
 
     public function testDelegatesToHandlerIfRouteResultNotAMethodFailure()
     {
-        $result = $this->prophesize(RouteResult::class);
-        $result->isMethodFailure()->willReturn(false);
+        $result = RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
 
-        $this->request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+        $this->request->getAttribute(RouteResult::class)->willReturn($result);
         $this->handler->handle(Argument::that([$this->request, 'reveal']))->will([$this->response, 'reveal']);
 
         $this->response->withStatus(Argument::any())->shouldNotBeCalled();
@@ -78,11 +78,9 @@ class MethodNotAllowedMiddlewareTest extends TestCase
 
     public function testReturns405ResponseWithAllowHeaderIfResultDueToMethodFailure()
     {
-        $result = $this->prophesize(RouteResult::class);
-        $result->isMethodFailure()->willReturn(true);
-        $result->getAllowedMethods()->willReturn(['GET', 'POST']);
+        $result = RouteResult::fromRouteFailure(['GET', 'POST']);
 
-        $this->request->getAttribute(RouteResult::class)->will([$result, 'reveal']);
+        $this->request->getAttribute(RouteResult::class)->willReturn($result);
         $this->handler->handle(Argument::that([$this->request, 'reveal']))->shouldNotBeCalled();
 
         $this->response->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)->will([$this->response, 'reveal']);


### PR DESCRIPTION
As discussed in #74 we replace all RouteResult mocking with instantiating class using static functions:
`fromRoute` and `fromRouteFailure`. PR based on #74.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

