### PR TITLE
Allow varying `RouteMiddlewareFactory` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.1.0 - TBD
+## 3.1.0 - 2018-06-05
 
 ### Added
 
@@ -10,7 +10,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#76](https://github.com/zendframework/zend-expressive-router/pull/76) modifies the `RouteMiddlewareFactory` to allow specifying a string
+  `$routererviceName` to its constructor. This change allows having discrete
+  factory instances for generating route middleware that use different router
+  instances.
 
 ### Deprecated
 

--- a/src/Middleware/RouteMiddlewareFactory.php
+++ b/src/Middleware/RouteMiddlewareFactory.php
@@ -23,19 +23,41 @@ use Zend\Expressive\Router\RouterInterface;
  */
 class RouteMiddlewareFactory
 {
+    /** @var string */
+    private $routerServiceName;
+
+    /**
+     * Allow serialization
+     */
+    public static function __set_state(array $data) : self
+    {
+        return new self(
+            $data['routerServiceName'] ?? RouterInterface::class
+        );
+    }
+
+    /**
+     * Provide the name of the router service to use when creating the route
+     * middleware.
+     */
+    public function __construct(string $routerServiceName = RouterInterface::class)
+    {
+        $this->routerServiceName = $routerServiceName;
+    }
+
     /**
      * @throws MissingDependencyException if the RouterInterface service is
      *     missing.
      */
     public function __invoke(ContainerInterface $container) : RouteMiddleware
     {
-        if (! $container->has(RouterInterface::class)) {
+        if (! $container->has($this->routerServiceName)) {
             throw MissingDependencyException::dependencyForService(
-                RouterInterface::class,
+                $this->routerServiceName,
                 RouteMiddleware::class
             );
         }
 
-        return new RouteMiddleware($container->get(RouterInterface::class));
+        return new RouteMiddleware($container->get($this->routerServiceName));
     }
 }

--- a/test/Middleware/RouteMiddlewareFactoryTest.php
+++ b/test/Middleware/RouteMiddlewareFactoryTest.php
@@ -49,4 +49,27 @@ class RouteMiddlewareFactoryTest extends TestCase
 
         $this->assertInstanceOf(RouteMiddleware::class, $middleware);
     }
+
+    public function testFactoryAllowsSpecifyingRouterServiceViaConstructor()
+    {
+        $router = $this->prophesize(RouterInterface::class)->reveal();
+        $this->container->has(Router::class)->willReturn(true);
+        $this->container->get(Router::class)->willReturn($router);
+
+        $factory = new RouteMiddlewareFactory(Router::class);
+
+        $middleware = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(RouteMiddleware::class, $middleware);
+        $this->assertAttributeSame($router, 'router', $middleware);
+    }
+
+    public function testFactoryIsSerializable()
+    {
+        $factory = RouteMiddlewareFactory::__set_state([
+            'routerServiceName' => Router::class,
+        ]);
+
+        $this->assertAttributeSame(Router::class, 'routerServiceName', $factory);
+    }
 }


### PR DESCRIPTION
This patch adds a new optional constructor argument to the `RouteMiddlewareFactory`, a string `$routerServiceName`. By default, it uses `Zend\Expressive\Router\RouterInterface` for the value. Users can, however, specify an alternate service class. This allows users to vary the `RouteMiddleware` per module or path-segregated middleware pipeline:

```php
// In configuration:
return [
    'dependencies' => [
        'factories' => [
            \Api\Router::class => FastRouteRouterFactory::class,
            \Api\RouteMiddleware::class => new RouteMiddlewareFactory(\Api\Router::class),
        ],
    ],
],

// In config/pipeline.php:
$app->pipe('/api', [
    \Api\RouteMiddleware::class,
    DispatchMiddleware::class,
]);
```

The factory implements `__set_state()`, allowing serialization via `var_export()` (the mechanism used by the default expressive configuration caching mechanism).