### PR TITLE
Remove "MUST raise Exception" from docblock of RouterInterface->match()

### DIFF
--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -26,7 +26,7 @@ interface RouterInterface
      * modify route instances before matching (e.g., to provide route options,
      * inject a name, etc.).
      *
-     * The method MUST raise Exception\RuntimeException if called after either `match()`
+     * The method CAN raise an Exception\RuntimeException if called after either `match()`
      * or `generateUri()` have already been called, to ensure integrity of the
      * router between invocations of either of those methods.
      *

--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -25,13 +25,6 @@ interface RouterInterface
      * `generateUri()` is called.  This is required to allow consumers to
      * modify route instances before matching (e.g., to provide route options,
      * inject a name, etc.).
-     *
-     * The method CAN raise an Exception\RuntimeException if called after either `match()`
-     * or `generateUri()` have already been called, to ensure integrity of the
-     * router between invocations of either of those methods.
-     *
-     * @throws Exception\RuntimeException when called after match() or
-     *     generateUri() have been called.
      */
     public function addRoute(Route $route) : void;
 


### PR DESCRIPTION
The docblock annotation of `RouterInterface` states that implementations MUST throw an exception if `addRoute` is called after calling `match()` or `generateUri()`.

Currently no implementation does this:
* [FastRoute](https://github.com/zendframework/zend-expressive-fastroute/blob/master/src/FastRouteRouter.php#L201)
* [Zend-Router](https://github.com/zendframework/zend-expressive-zendrouter/blob/master/src/ZendRouter.php#L88)
* [Aura.Router](https://github.com/zendframework/zend-expressive-aurarouter/blob/master/src/AuraRouter.php#L78)

I've opened an [issue in the FastRoute wrapper repo](https://github.com/zendframework/zend-expressive-fastroute/issues/60)  and @froschdesign and @xtreamwayz seem to indicate that they want to change the "MUST" to a "CAN".

Whats your opinion?