### PR TITLE
Add code style rule for array brackets spacing

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Zend Framework coding standard">
     <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
-
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>


### PR DESCRIPTION
Disallow spacing around array brackets in phpcs.